### PR TITLE
Major release fix and version bump

### DIFF
--- a/AnimeUnity/build.gradle.kts
+++ b/AnimeUnity/build.gradle.kts
@@ -1,5 +1,5 @@
 // use an integer for version numbers
-version = 11
+version = 12
 
 
 cloudstream {

--- a/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnityExtractor.kt
+++ b/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnityExtractor.kt
@@ -7,6 +7,8 @@ import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.AppUtils.parseJson
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.ExtractorLinkType
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
 import okhttp3.HttpUrl.Companion.toHttpUrl
 
@@ -26,14 +28,14 @@ class AnimeUnityExtractor : ExtractorApi() {
         val masterPlaylist = getMasterPlaylistUrl(url)
         if (url.isNotEmpty()) {
             callback.invoke(
-                ExtractorLink(
+                newExtractorLink(
                     source = "Vixcloud",
                     name = "AnimeUnity",
                     url = masterPlaylist,
-                    referer = referer!!,
-                    isM3u8 = true,
-                    quality = Qualities.Unknown.value
-                )
+                ) {
+                    this.referer = referer!!
+                    this.quality = Qualities.Unknown.value
+                }
             )
         }
     }

--- a/AnimeWorld/build.gradle.kts
+++ b/AnimeWorld/build.gradle.kts
@@ -1,5 +1,5 @@
 // use an integer for version numbers
-version = 13
+version = 14
 
 
 cloudstream {

--- a/AnimeWorld/src/main/kotlin/it/dogior/hadEnough/AnimeWorldCore.kt
+++ b/AnimeWorld/src/main/kotlin/it/dogior/hadEnough/AnimeWorldCore.kt
@@ -33,6 +33,8 @@ import com.lagradost.cloudstream3.newHomePageResponse
 import com.lagradost.cloudstream3.newMovieLoadResponse
 import com.lagradost.cloudstream3.utils.AppUtils.tryParseJson
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.ExtractorLinkType
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.loadExtractor
 import com.lagradost.nicehttp.NiceResponse
@@ -382,13 +384,14 @@ open class AnimeWorldCore(isSplit: Boolean = false) : MainAPI() {
         apiResults.amap {
             if (it.target.contains("AnimeWorld")) {
                 callback.invoke(
-                    ExtractorLink(
+                    newExtractorLink(
                         name,
                         "AnimeWorld",
                         it.grabber,
-                        referer = mainUrl,
-                        quality = Qualities.Unknown.value
-                    )
+                    ) {
+                        this.referer = mainUrl
+                        this.quality = Qualities.Unknown.value
+                    }
                 )
 
             } else if (it.target.contains("listeamed.net")) {

--- a/AnimeWorld/src/main/kotlin/it/dogior/hadEnough/VidguardExtractor.kt
+++ b/AnimeWorld/src/main/kotlin/it/dogior/hadEnough/VidguardExtractor.kt
@@ -7,6 +7,8 @@ import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.AppUtils.tryParseJson
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.ExtractorLinkType
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
 import org.mozilla.javascript.Context
 import org.mozilla.javascript.NativeJSON.stringify
@@ -32,14 +34,15 @@ class VidguardExtractor : ExtractorApi() {
         val playlistUrl = sigDecode(json.stream)
 
         callback.invoke(
-            ExtractorLink(
+            newExtractorLink(
                 "VidGuard",
                 "VidGuard",
                 playlistUrl,
-                referer = mainUrl,
-                quality = Qualities.Unknown.value,
-                isM3u8 = true
-            )
+                type = ExtractorLinkType.M3U8
+            ){
+                this.referer = mainUrl
+                this.quality = Qualities.Unknown.value
+            }
         )
     }
 

--- a/CB01/build.gradle.kts
+++ b/CB01/build.gradle.kts
@@ -1,5 +1,5 @@
 // use an integer for version numbers
-version = 9
+version = 10
 
 
 cloudstream {

--- a/CB01/src/main/kotlin/it/dogior/hadEnough/CB01.kt
+++ b/CB01/src/main/kotlin/it/dogior/hadEnough/CB01.kt
@@ -40,7 +40,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 
 class CB01 : MainAPI() {
-    override var mainUrl = "https://cb01.uno"
+    override var mainUrl = "https://cb01net.one/"
     override var name = "CB01"
     override val supportedTypes = setOf(TvType.Movie, TvType.TvSeries, TvType.Cartoon)
     override var lang = "it"

--- a/CB01/src/main/kotlin/it/dogior/hadEnough/extractors/MaxStreamExtractor.kt
+++ b/CB01/src/main/kotlin/it/dogior/hadEnough/extractors/MaxStreamExtractor.kt
@@ -5,6 +5,8 @@ import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.ExtractorLinkType
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.getAndUnpack
 import java.io.File
@@ -39,14 +41,15 @@ class MaxStreamExtractor : ExtractorApi() {
         val src = unpackedScript.substringAfter("src:\"").substringBefore("\",")
         Log.d("MaxStream", "Script: $src")
         callback.invoke(
-            ExtractorLink(
+            newExtractorLink(
                 source = name,
                 name = name,
                 url = src,
-                referer = referer ?: "",
-                quality = Qualities.Unknown.value,
-                isM3u8 = true
-            )
+                type = ExtractorLinkType.M3U8
+            ) {
+                this.referer = referer ?: ""
+                this.quality = Qualities.Unknown.value
+            }
         )
     }
 }

--- a/CalcioStreaming/build.gradle.kts
+++ b/CalcioStreaming/build.gradle.kts
@@ -1,5 +1,5 @@
 // use an integer for version numbers
-version = 3
+version = 4
 
 
 cloudstream {

--- a/CalcioStreaming/src/main/kotlin/it/dogior/hadEnough/CalcioStreaming.kt
+++ b/CalcioStreaming/src/main/kotlin/it/dogior/hadEnough/CalcioStreaming.kt
@@ -11,7 +11,7 @@ import org.jsoup.nodes.Document
 
 class CalcioStreaming : MainAPI() {
     override var lang = "it"
-    override var mainUrl = "https://calciostreaming.day"
+    override var mainUrl = "https://guardacalcio.cam" // Cambio totale di dominio. Valutare un cambio di naming dell'estensione
     override var name = "CalcioStreaming"
     override val hasMainPage = true
     override val hasChromecastSupport = true
@@ -94,14 +94,15 @@ class CalcioStreaming : MainAPI() {
                 if (newPage.select("script").size >= 6 && streamUrl != null){
                     videoNotFound = false
                     callback(
-                        ExtractorLink(
-                            this.name,
-                            button.text(),
-                            streamUrl,
-                            fixUrl(link),
-                            quality = 0,
-                            true
-                        )
+                        newExtractorLink(
+                            source = this.name,
+                            name = button.text(),
+                            url = streamUrl,
+                            type = ExtractorLinkType.M3U8
+                        ){
+                            this.quality = 0
+                            this.referer = fixUrl(link)
+                        }
                     )
                 }
             }

--- a/DaddyLive/build.gradle.kts
+++ b/DaddyLive/build.gradle.kts
@@ -1,5 +1,5 @@
 // use an integer for version numbers
-version = 8
+version = 9
 
 
 cloudstream {

--- a/DaddyLive/src/main/kotlin/it/dogior/hadEnough/DaddyLiveExtractor.kt
+++ b/DaddyLive/src/main/kotlin/it/dogior/hadEnough/DaddyLiveExtractor.kt
@@ -6,6 +6,8 @@ import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.AppUtils.tryParseJson
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.ExtractorLinkType
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
 import java.net.URL
 import java.net.URLEncoder
@@ -68,19 +70,21 @@ class DaddyLiveExtractor : ExtractorApi() {
 
         val finalLink = "https://$key.newkso.ru/$key/$url2$m3u8"
 
-        return ExtractorLink(
+        return newExtractorLink(
             sourceName,
             sourceName,
             finalLink,
-            referer = "",
-            isM3u8 = true,
-            headers = mapOf(
+            type = ExtractorLinkType.M3U8,
+        ) {
+            this.referer = ""
+            this.quality = Qualities.Unknown.value
+            this.headers = mapOf(
                 "Referer" to ref,
                 "Origin" to ref,
                 "Keep-Alive" to "true",
                 "User-Agent" to userAgent
-            ),
-            quality = Qualities.Unknown.value
-        )
+            )
+        }
+        
     }
 }

--- a/Huhu/build.gradle.kts
+++ b/Huhu/build.gradle.kts
@@ -1,5 +1,5 @@
 // use an integer for version numbers
-version = 2
+version = 3
 
 
 cloudstream {

--- a/Huhu/src/main/kotlin/it/dogior/hadEnough/Huhu.kt
+++ b/Huhu/src/main/kotlin/it/dogior/hadEnough/Huhu.kt
@@ -18,6 +18,8 @@ import com.lagradost.cloudstream3.newHomePageResponse
 import com.lagradost.cloudstream3.utils.AppUtils.parseJson
 import com.lagradost.cloudstream3.utils.AppUtils.toJson
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.ExtractorLinkType
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
 
 class Huhu(domain: String, private val countries: Map<String, Boolean>, language: String) : MainAPI() {
@@ -92,14 +94,15 @@ class Huhu(domain: String, private val countries: Map<String, Boolean>, language
         callback: (ExtractorLink) -> Unit,
     ): Boolean {
         callback(
-            ExtractorLink(
+            newExtractorLink(
                 this.name,
                 this.name,
                 data,
-                referer = "",
-                quality = Qualities.Unknown.value,
-                isM3u8 = true
-            )
+                type = ExtractorLinkType.M3U8
+            ){
+                this.referer = ""
+                this.quality = Qualities.Unknown.value
+            }
         )
         return true
     }

--- a/OnlineSerieTV/build.gradle.kts
+++ b/OnlineSerieTV/build.gradle.kts
@@ -1,5 +1,5 @@
 // use an integer for version numbers
-version = 2
+version = 3
 
 
 cloudstream {

--- a/OnlineSerieTV/src/main/kotlin/it/dogior/hadEnough/extractors/MaxStreamExtractor.kt
+++ b/OnlineSerieTV/src/main/kotlin/it/dogior/hadEnough/extractors/MaxStreamExtractor.kt
@@ -5,6 +5,8 @@ import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.ExtractorLinkType
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.getAndUnpack
 
@@ -37,14 +39,15 @@ class MaxStreamExtractor : ExtractorApi() {
         val src = unpackedScript.substringAfter("src:\"").substringBefore("\",")
         Log.d("MaxStream", "Script: $src")
         callback.invoke(
-            ExtractorLink(
+            newExtractorLink(
                 source = name,
                 name = name,
                 url = src,
-                referer = referer ?: "",
-                quality = Qualities.Unknown.value,
-                isM3u8 = true
-            )
+                type = ExtractorLinkType.M3U8
+            ){
+                this.referer = referer ?: ""
+                this.quality = Qualities.Unknown.value
+            }
         )
     }
 }

--- a/OnlineSerieTV/src/main/kotlin/it/dogior/hadEnough/extractors/StreamTapeExtractor.kt
+++ b/OnlineSerieTV/src/main/kotlin/it/dogior/hadEnough/extractors/StreamTapeExtractor.kt
@@ -4,6 +4,8 @@ import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.ExtractorLinkType
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
 
 class StreamTapeExtractor: ExtractorApi() {
@@ -32,13 +34,14 @@ class StreamTapeExtractor: ExtractorApi() {
                 script.substringAfter("+ ('xcd").substringBefore("'")
 
         callback.invoke(
-            ExtractorLink(
+            newExtractorLink(
                 name,
                 name,
-                videoUrl,
-                "",
-                Qualities.Unknown.value
-            )
+                videoUrl
+            ) {
+                this.referer = referer ?: ""
+                this.quality = Qualities.Unknown.value
+            }
         )
 
     }

--- a/StreamingCommunity/build.gradle.kts
+++ b/StreamingCommunity/build.gradle.kts
@@ -1,5 +1,5 @@
 // use an integer for version numbers
-version = 13
+version = 14
 
 
 cloudstream {

--- a/StreamingCommunity/src/main/kotlin/it/dogior/hadEnough/StreamingCommunity.kt
+++ b/StreamingCommunity/src/main/kotlin/it/dogior/hadEnough/StreamingCommunity.kt
@@ -42,7 +42,7 @@ class StreamingCommunity : MainAPI() {
                 "X-Inertia" to true.toString(),
                 "X-Inertia-Version" to inertiaVersion
             ).toMutableMap()
-        val mainUrl = "https://streamingcommunity.lu"
+        val mainUrl = "https://streamingcommunity.airforce"
         var name = "StreamingCommunity"
     }
 

--- a/StreamingCommunity/src/main/kotlin/it/dogior/hadEnough/StreamingCommunityExtractor.kt
+++ b/StreamingCommunity/src/main/kotlin/it/dogior/hadEnough/StreamingCommunityExtractor.kt
@@ -7,6 +7,8 @@ import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.AppUtils.parseJson
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.ExtractorLinkType
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
 import okhttp3.HttpUrl.Companion.toHttpUrl
 
@@ -32,14 +34,15 @@ class StreamingCommunityExtractor : ExtractorApi() {
             Log.w(TAG, "FINAL URL: $playlistUrl")
 
             callback.invoke(
-                ExtractorLink(
+                newExtractorLink(
                     source = "Vixcloud",
                     name = "Streaming Community",
                     url = playlistUrl,
-                    referer = referer!!,
-                    isM3u8 = true,
-                    quality = Qualities.Unknown.value
-                )
+                    type = ExtractorLinkType.M3U8
+                ) {
+                    this.referer = referer!!
+                    this.quality = Qualities.Unknown.value
+                }
             )
         }
 

--- a/TV/build.gradle.kts
+++ b/TV/build.gradle.kts
@@ -1,5 +1,5 @@
 // use an integer for version numbers
-version = 2
+version = 3
 
 cloudstream {
     // All of these properties are optional, you can safely remove them

--- a/TV/src/main/kotlin/it/dogior/hadEnough/TV.kt
+++ b/TV/src/main/kotlin/it/dogior/hadEnough/TV.kt
@@ -6,6 +6,8 @@ import com.lagradost.cloudstream3.APIHolder.capitalize
 import com.lagradost.cloudstream3.utils.AppUtils.parseJson
 import com.lagradost.cloudstream3.utils.AppUtils.toJson
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.ExtractorLinkType
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
 
 class TV(
@@ -102,14 +104,15 @@ class TV(
     ): Boolean {
 
         callback.invoke(
-            ExtractorLink(
+            newExtractorLink(
                 "Free-TV",
                 "Free-TV",
                 data,
-                "",
-                Qualities.Unknown.value,
-                isM3u8 = true
-            )
+                type = ExtractorLinkType.M3U8
+            ) {
+                this.referer = ""
+                this.quality = Qualities.Unknown.value
+            }
         )
         return true
     }

--- a/ToonItalia/build.gradle.kts
+++ b/ToonItalia/build.gradle.kts
@@ -1,5 +1,5 @@
 // use an integer for version numbers
-version = 3
+version = 4
 
 cloudstream {
     // All of these properties are optional, you can safely remove them

--- a/ToonItalia/src/main/kotlin/it/dogior/hadEnough/extractors/MaxStreamExtractor.kt
+++ b/ToonItalia/src/main/kotlin/it/dogior/hadEnough/extractors/MaxStreamExtractor.kt
@@ -5,6 +5,8 @@ import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.ExtractorLinkType
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.getAndUnpack
 import java.io.File
@@ -39,14 +41,15 @@ class MaxStreamExtractor : ExtractorApi() {
         val src = unpackedScript.substringAfter("src:\"").substringBefore("\",")
         Log.d("MaxStream", "Script: $src")
         callback.invoke(
-            ExtractorLink(
+            newExtractorLink(
                 source = name,
                 name = name,
                 url = src,
-                referer = referer ?: "",
-                quality = Qualities.Unknown.value,
-                isM3u8 = true
-            )
+                type = ExtractorLinkType.M3U8
+            ){
+                this.referer = referer ?: ""
+                this.quality = Qualities.Unknown.value
+            }
         )
     }
 }

--- a/ToonItalia/src/main/kotlin/it/dogior/hadEnough/extractors/StreamTapeExtractor.kt
+++ b/ToonItalia/src/main/kotlin/it/dogior/hadEnough/extractors/StreamTapeExtractor.kt
@@ -4,6 +4,8 @@ import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.ExtractorLinkType
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
 
 class StreamTapeExtractor: ExtractorApi() {
@@ -32,13 +34,14 @@ class StreamTapeExtractor: ExtractorApi() {
                 script.substringAfter("+ ('xcd").substringBefore("'")
 
         callback.invoke(
-            ExtractorLink(
-                name,
-                name,
-                videoUrl,
-                "",
-                Qualities.Unknown.value
-            )
+            newExtractorLink(
+                source = name,
+                name = name,
+                url = videoUrl
+            ) {
+                this.referer = referer ?: ""
+                this.quality = Qualities.Unknown.value
+            }
         )
 
     }

--- a/YouTube/build.gradle.kts
+++ b/YouTube/build.gradle.kts
@@ -1,7 +1,7 @@
 @file:Suppress("UnstableApiUsage")
 
 // use an integer for version numbers
-version = 11
+version = 12
 
 cloudstream {
     description = "Videos, playlists and channels from YouTube"

--- a/YouTube/src/main/kotlin/it/dogior/hadEnough/YouTubeExtractor.kt
+++ b/YouTube/src/main/kotlin/it/dogior/hadEnough/YouTubeExtractor.kt
@@ -5,6 +5,8 @@ import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.mvvm.logError
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.ExtractorLinkType
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import com.lagradost.cloudstream3.utils.M3u8Helper
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.schemaStripRegex
@@ -41,14 +43,15 @@ open class YouTubeExtractor(private val hls: Boolean) : ExtractorApi() {
         Log.d("YoutubeExtractor", "HLS Url: ${extractor.hlsUrl}")
         if (hls) {
             callback.invoke(
-                ExtractorLink(
+                newExtractorLink(
                     this.name,
                     this.name,
                     extractor.hlsUrl,
-                    referer ?: "",
-                    quality = Qualities.Unknown.value,
-                    isM3u8 = true
-                )
+                    type = ExtractorLinkType.M3U8
+                ) {
+                    this.referer = referer ?: ""
+                    this.quality = Qualities.Unknown.value
+                }
             )
         } else {
             val stream = M3u8Helper.generateM3u8(this.name, extractor.hlsUrl, "")


### PR DESCRIPTION
### Cosa è stato fatto

1. `ExtractorLink`: deprecata. Usare la nuova `newExtractorLink`

Pull Request: https://github.com/recloudstream/cloudstream/pull/1632
Dokka: https://recloudstream.github.io/dokka/library/com.lagradost.cloudstream3.utils/new-extractor-link.html

2. URLs e versioni aggiornati.

_________________

### Cose da valutare per future implementazioni:

1. Calciostreaming è diventato Guardacalcio. Valutare se rinominare l'estensione.
2. OnlineSerieTV è protetto da Cloudflare ma sembra esserci un bug che causa un loop e nega l'accesso ai dispositivi Android su Chrome #17
3. Valutare inserimento di alternative a OnlineSerieTV sostituendole con alternative valide:

- AltaDefinizione e Guardaserie fornite da @ZCban #16 
- AltaDefinizione.gent nella mia repo `testing-private`

