### PR TITLE
Update mainUrl to new Streaming Community URL

### DIFF
--- a/StreamingCommunity/src/main/kotlin/it/dogior/hadEnough/StreamingCommunity.kt
+++ b/StreamingCommunity/src/main/kotlin/it/dogior/hadEnough/StreamingCommunity.kt
@@ -48,7 +48,7 @@ class StreamingCommunity(override var lang: String = "it") : MainAPI() {
             "X-Inertia-Version" to inertiaVersion,
             "X-Requested-With" to "XMLHttpRequest",
         ).toMutableMap()
-        val mainUrl = "https://streamingunity.club/"
+        val mainUrl = "https://streamingcommunityz.motorcycles/"
         var name = "StreamingCommunity"
         val TAG = "SCommunity"
     }


### PR DESCRIPTION
The new StreamingUnity website now requires user registration to access the content. StreamingCommunityZ, instead, allows users to watch videos without registration, so no changes to the current code flow are required.