### PR TITLE
Nuove sezioni per AnimeUnity + visualizzazione Valutazione

### DIFF
--- a/AnimeUnity/build.gradle.kts
+++ b/AnimeUnity/build.gradle.kts
@@ -1,5 +1,5 @@
 // use an integer for version numbers
-version = 15
+version = 16
 
 
 cloudstream {
@@ -23,7 +23,17 @@ cloudstream {
     )
 
     language = "it"
-    requiresResources = false
+    requiresResources = true
 
     iconUrl = "https://www.animeunity.so/apple-touch-icon.png"
+}
+
+android {
+    buildFeatures {
+        buildConfig = true
+    }
+}
+
+dependencies {
+    implementation("com.google.android.material:material:1.12.0")
 }

--- a/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnity.kt
+++ b/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnity.kt
@@ -1,5 +1,6 @@
 package it.dogior.hadEnough
 
+import android.content.SharedPreferences
 import com.lagradost.api.Log
 import com.lagradost.cloudstream3.DubStatus
 import com.lagradost.cloudstream3.HomePageList
@@ -11,6 +12,7 @@ import com.lagradost.cloudstream3.LoadResponse.Companion.addMalId
 import com.lagradost.cloudstream3.LoadResponse.Companion.addScore
 import com.lagradost.cloudstream3.MainAPI
 import com.lagradost.cloudstream3.MainPageRequest
+import com.lagradost.cloudstream3.Score
 import com.lagradost.cloudstream3.SearchResponse
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.TvType
@@ -27,6 +29,9 @@ import com.lagradost.cloudstream3.newHomePageResponse
 import com.lagradost.cloudstream3.utils.AppUtils.parseJson
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import java.text.Normalizer
+import java.text.SimpleDateFormat
+import java.util.Date
 import java.util.Locale
 
 typealias Str = BooleanOrString.AsString
@@ -34,7 +39,9 @@ typealias Str = BooleanOrString.AsString
 
 const val TAG = "AnimeUnity"
 
-class AnimeUnity : MainAPI() {
+class AnimeUnity(
+    private val sharedPref: SharedPreferences?,
+) : MainAPI() {
     override var mainUrl = Companion.mainUrl
     override var name = Companion.name
     override var supportedTypes = setOf(TvType.Anime, TvType.AnimeMovie, TvType.OVA)
@@ -44,6 +51,8 @@ class AnimeUnity : MainAPI() {
     companion object {
         @Suppress("ConstPropertyName")
         const val mainUrl = "https://www.animeunity.so"
+        const val latestEpisodesSectionName = "Ultimi Episodi"
+        const val calendarSectionName = "Calendario"
         var name = "AnimeUnity"
         var headers = mapOf(
             "Host" to mainUrl.toHttpUrl().host,
@@ -52,17 +61,39 @@ class AnimeUnity : MainAPI() {
 //        var cookies = emptyMap<String, String>()
     }
 
-    private val sectionNamesList = mainPageOf(
-        "$mainUrl/archivio/" to "In Corso",
-        "$mainUrl/archivio/" to "Popolari",
-        "$mainUrl/archivio/" to "I migliori",
-        "$mainUrl/archivio/" to "In Arrivo",
-//        "$mainUrl/archivio/" to "I migliori doppiati",
-//        "$mainUrl/archivio/" to "In Corso doppiati",
-//        "$mainUrl/archivio/" to "Popolari doppiati",
-//        "$mainUrl/archivio/" to "I migliori doppiati",
-    )
+    private val sectionNamesList = buildSectionNamesList()
     override val mainPage = sectionNamesList
+
+    private fun buildSectionNamesList() = mainPageOf(
+        *buildList {
+            if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_LATEST_EPISODES)) {
+                add("$mainUrl/" to latestEpisodesSectionName)
+            }
+            if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_CALENDAR)) {
+                add("$mainUrl/calendario" to calendarSectionName)
+            }
+            if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_ONGOING)) {
+                add("$mainUrl/archivio/" to "In Corso")
+            }
+            if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_POPULAR)) {
+                add("$mainUrl/archivio/" to "Popolari")
+            }
+            if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_BEST)) {
+                add("$mainUrl/archivio/" to "I migliori")
+            }
+            if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_UPCOMING)) {
+                add("$mainUrl/archivio/" to "In Arrivo")
+            }
+        }.toTypedArray()
+    )
+
+    private fun isSectionEnabled(prefKey: String): Boolean {
+        return sharedPref?.getBoolean(prefKey, true) ?: true
+    }
+
+    private fun shouldShowScore(): Boolean {
+        return sharedPref?.getBoolean(AnimeUnityPlugin.PREF_SHOW_SCORE, true) ?: true
+    }
 
 
     private suspend fun setupHeadersAndCookies() {
@@ -110,8 +141,35 @@ class AnimeUnity : MainAPI() {
             ).apply {
                 addDubStatus(anime.dub == 1 || title.contains("(ITA)"))
                 addPoster(poster)
+                if (shouldShowScore()) {
+                    this.score = Score.from(anime.score, 10)
+                }
             }
 
+        }
+    }
+
+    private suspend fun latestEpisodesResponseBuilder(objectList: List<LatestEpisodeItem>): List<SearchResponse> {
+        return objectList.amap { item ->
+            val anime = item.anime
+            val title = (anime.titleIt ?: anime.titleEng ?: anime.title!!)
+            val poster = getImage(anime.imageUrl, anime.anilistId)
+
+            newAnimeSearchResponse(
+                name = "${title.replace(" (ITA)", "")} - Ep. ${item.number}",
+                url = "$mainUrl/anime/${anime.id}-${anime.slug}",
+                type = when {
+                    anime.type == "TV" -> TvType.Anime
+                    anime.type == "Movie" || anime.episodesCount == 1 -> TvType.AnimeMovie
+                    else -> TvType.OVA
+                }
+            ).apply {
+                addDubStatus(anime.dub == 1 || title.contains("(ITA)"))
+                addPoster(poster)
+                if (shouldShowScore()) {
+                    this.score = Score.from(anime.score, 10)
+                }
+            }
         }
     }
 
@@ -159,6 +217,12 @@ class AnimeUnity : MainAPI() {
     //Get the Homepage
     override suspend fun getMainPage(page: Int, request: MainPageRequest): HomePageResponse {
 //        val localTag = "$TAG:MainPage"
+        if (request.name == latestEpisodesSectionName) {
+            return getLatestEpisodesMainPage(page)
+        }
+        if (request.name == calendarSectionName) {
+            return getCalendarMainPage(page, request)
+        }
 
         val url = request.data + "get-animes"
         if (!headers.contains("Cookie")) {
@@ -198,6 +262,94 @@ class AnimeUnity : MainAPI() {
                 isHorizontalImages = false
             ), hasNextPage
         )
+    }
+
+    private suspend fun getLatestEpisodesMainPage(page: Int): HomePageResponse {
+        if (page > 1) {
+            return newHomePageResponse(
+                HomePageList(
+                    name = latestEpisodesSectionName,
+                    list = emptyList(),
+                    isHorizontalImages = false
+                ),
+                false
+            )
+        }
+
+        val latestEpisodesJson = app.get("$mainUrl/?page=1").document
+            .selectFirst("#ultimi-episodi layout-items")
+            ?.attr("items-json")
+            .orEmpty()
+
+        val latestEpisodes = latestEpisodesJson
+            .takeIf(String::isNotBlank)
+            ?.let { json ->
+                runCatching { parseJson<LatestEpisodesPage>(json).episodes }.getOrDefault(emptyList())
+            }
+            ?: emptyList()
+
+        return newHomePageResponse(
+            HomePageList(
+                name = latestEpisodesSectionName,
+                list = latestEpisodesResponseBuilder(latestEpisodes),
+                isHorizontalImages = false
+            ),
+            false
+        )
+    }
+
+    private suspend fun getCalendarMainPage(
+        page: Int,
+        request: MainPageRequest,
+    ): HomePageResponse {
+        val currentDay = getCurrentItalianDayName()
+        val calendarTitle = "$calendarSectionName ($currentDay)"
+
+        if (page > 1) {
+            return newHomePageResponse(
+                HomePageList(
+                    name = calendarTitle,
+                    list = emptyList(),
+                    isHorizontalImages = false
+                ),
+                false
+            )
+        }
+
+        val calendarAnime = app.get(request.data).document
+            .select("calendario-item")
+            .mapNotNull { item ->
+                item.attr("a")
+                    .takeIf(String::isNotBlank)
+                    ?.let { animeJson ->
+                        runCatching { parseJson<Anime>(animeJson) }.getOrNull()
+                    }
+            }
+            .filter { normalizeDayName(it.day) == normalizeDayName(currentDay) }
+            .distinctBy { it.id }
+
+        return newHomePageResponse(
+            HomePageList(
+                name = calendarTitle,
+                list = searchResponseBuilder(calendarAnime),
+                isHorizontalImages = false
+            ),
+            false
+        )
+    }
+
+    private fun getCurrentItalianDayName(): String {
+        val formatter = SimpleDateFormat("EEEE", Locale.ITALIAN)
+        return formatter.format(Date()).replaceFirstChar {
+            if (it.isLowerCase()) it.titlecase(Locale.ITALIAN) else it.toString()
+        }
+    }
+
+    private fun normalizeDayName(dayName: String?): String {
+        return Normalizer.normalize(dayName.orEmpty(), Normalizer.Form.NFD)
+            .replace("\\p{M}+".toRegex(), "")
+            .trim()
+            .lowercase(Locale.ROOT)
     }
 
     private fun getDataPerHomeSection(section: String) = when (section) {

--- a/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnityDTOs.kt
+++ b/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnityDTOs.kt
@@ -82,7 +82,7 @@ data class Anime(
     @JsonProperty("type") val type: String,
     @JsonProperty("slug") val slug: String,
     @JsonProperty("title_eng") val titleEng: String?,
-//    @JsonProperty("day") val day: String?,
+    @JsonProperty("day") val day: String?,
     @JsonProperty("score") val score: String?,
 //    @JsonProperty("studio") val studio: String,
     @JsonProperty("dub") val dub: Int,
@@ -99,7 +99,7 @@ data class Anime(
 data class Episode(
     @JsonProperty("id") val id: Int,
     @JsonProperty("anime_id") val animeId: Int,
-    @JsonProperty("user_id") val userId: Int,
+    @JsonProperty("user_id") val userId: Int?,
     @JsonProperty("number") val number: String,
     @JsonProperty("link") val link: String,
     @JsonProperty("visite") val visite: Int,
@@ -107,6 +107,34 @@ data class Episode(
     @JsonProperty("public") val isPublic: Int,
     @JsonProperty("scws_id") val scwsId: Int,
     @JsonProperty("file_name") val fileName: String?
+)
+
+data class LatestEpisodesPage(
+    @JsonProperty("current_page") val currentPage: Int,
+    @JsonProperty("data") val episodes: List<LatestEpisodeItem>
+)
+
+data class LatestEpisodeItem(
+    @JsonProperty("id") val id: Int,
+    @JsonProperty("anime_id") val animeId: Int,
+    @JsonProperty("user_id") val userId: Int?,
+    @JsonProperty("number") val number: String,
+    @JsonProperty("anime") val anime: LatestEpisodeAnime
+)
+
+data class LatestEpisodeAnime(
+    @JsonProperty("id") val id: Int,
+    @JsonProperty("title") val title: String?,
+    @JsonProperty("imageurl") val imageUrl: String?,
+    @JsonProperty("episodes_count") val episodesCount: Int,
+    @JsonProperty("type") val type: String,
+    @JsonProperty("slug") val slug: String,
+    @JsonProperty("title_eng") val titleEng: String?,
+    @JsonProperty("score") val score: String?,
+    @JsonProperty("dub") val dub: Int,
+    @JsonProperty("cover") val cover: String?,
+    @JsonProperty("anilist_id") val anilistId: Int?,
+    @JsonProperty("title_it") val titleIt: String?
 )
 
 data class AnimeInfo(

--- a/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnityPlugin.kt
+++ b/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnityPlugin.kt
@@ -1,12 +1,34 @@
 package it.dogior.hadEnough
 
 import android.content.Context
+import android.content.SharedPreferences
+import androidx.appcompat.app.AppCompatActivity
 import com.lagradost.cloudstream3.plugins.CloudstreamPlugin
 import com.lagradost.cloudstream3.plugins.Plugin
 
 @CloudstreamPlugin
 class AnimeUnityPlugin : Plugin() {
+    companion object {
+        const val PREFS_NAME = "AnimeUnity"
+        const val PREF_SHOW_LATEST_EPISODES = "showLatestEpisodes"
+        const val PREF_SHOW_CALENDAR = "showCalendar"
+        const val PREF_SHOW_ONGOING = "showOngoing"
+        const val PREF_SHOW_POPULAR = "showPopular"
+        const val PREF_SHOW_BEST = "showBest"
+        const val PREF_SHOW_UPCOMING = "showUpcoming"
+        const val PREF_SHOW_SCORE = "showScore"
+    }
+
+    private var sharedPref: SharedPreferences? = null
+
     override fun load(context: Context) {
-        registerMainAPI(AnimeUnity())
+        sharedPref = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+        registerMainAPI(AnimeUnity(sharedPref))
+
+        openSettings = { ctx ->
+            val activity = ctx as AppCompatActivity
+            AnimeUnitySettings(this, sharedPref).show(activity.supportFragmentManager, "AnimeUnitySettings")
+        }
     }
 }

--- a/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnitySettings.kt
+++ b/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnitySettings.kt
@@ -1,0 +1,156 @@
+package it.dogior.hadEnough
+
+import android.annotation.SuppressLint
+import android.content.SharedPreferences
+import android.graphics.drawable.Drawable
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageButton
+import android.widget.Switch
+import android.widget.TextView
+import androidx.core.content.res.ResourcesCompat
+import androidx.core.content.edit
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.lagradost.cloudstream3.CommonActivity.showToast
+
+class AnimeUnitySettings(
+    private val plugin: AnimeUnityPlugin,
+    private val sharedPref: SharedPreferences?,
+) : BottomSheetDialogFragment() {
+
+    private fun View.makeTvCompatible() {
+        this.setPadding(
+            this.paddingLeft + 10,
+            this.paddingTop + 10,
+            this.paddingRight + 10,
+            this.paddingBottom + 10
+        )
+        this.background = getDrawable("outline")
+    }
+
+    @SuppressLint("DiscouragedApi")
+    @Suppress("SameParameterValue")
+    private fun getDrawable(name: String): Drawable? {
+        val id = plugin.resources?.getIdentifier(name, "drawable", BuildConfig.LIBRARY_PACKAGE_NAME)
+        return id?.let { ResourcesCompat.getDrawable(plugin.resources ?: return null, it, null) }
+    }
+
+    @SuppressLint("DiscouragedApi")
+    @Suppress("SameParameterValue")
+    private fun getString(name: String): String? {
+        val id = plugin.resources?.getIdentifier(name, "string", BuildConfig.LIBRARY_PACKAGE_NAME)
+        return id?.let { plugin.resources?.getString(it) }
+    }
+
+    @SuppressLint("DiscouragedApi")
+    private fun <T : View> View.findViewByName(name: String): T? {
+        val id = plugin.resources?.getIdentifier(name, "id", BuildConfig.LIBRARY_PACKAGE_NAME)
+        return findViewById(id ?: return null)
+    }
+
+    @SuppressLint("DiscouragedApi")
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val layoutId =
+            plugin.resources?.getIdentifier("settings", "layout", BuildConfig.LIBRARY_PACKAGE_NAME)
+        return layoutId?.let {
+            inflater.inflate(plugin.resources?.getLayout(it), container, false)
+        }
+    }
+
+    @SuppressLint("UseSwitchCompatOrMaterialCode")
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val headerTw: TextView? = view.findViewByName("header_tw")
+        headerTw?.text = getString("header_tw")
+
+        val sectionsLabel: TextView? = view.findViewByName("sections_label")
+        sectionsLabel?.text = getString("sections_label")
+
+        val displayLabel: TextView? = view.findViewByName("display_label")
+        displayLabel?.text = getString("display_label")
+
+        val latestEpisodesSwitch: Switch? = view.findViewByName("latest_episodes_switch")
+        latestEpisodesSwitch?.text = getString("latest_episodes_switch_text")
+        latestEpisodesSwitch?.isChecked =
+            sharedPref?.getBoolean(AnimeUnityPlugin.PREF_SHOW_LATEST_EPISODES, true) ?: true
+
+        val calendarSwitch: Switch? = view.findViewByName("calendar_switch")
+        calendarSwitch?.text = getString("calendar_switch_text")
+        calendarSwitch?.isChecked =
+            sharedPref?.getBoolean(AnimeUnityPlugin.PREF_SHOW_CALENDAR, true) ?: true
+
+        val ongoingSwitch: Switch? = view.findViewByName("ongoing_switch")
+        ongoingSwitch?.text = getString("ongoing_switch_text")
+        ongoingSwitch?.isChecked =
+            sharedPref?.getBoolean(AnimeUnityPlugin.PREF_SHOW_ONGOING, true) ?: true
+
+        val popularSwitch: Switch? = view.findViewByName("popular_switch")
+        popularSwitch?.text = getString("popular_switch_text")
+        popularSwitch?.isChecked =
+            sharedPref?.getBoolean(AnimeUnityPlugin.PREF_SHOW_POPULAR, true) ?: true
+
+        val bestSwitch: Switch? = view.findViewByName("best_switch")
+        bestSwitch?.text = getString("best_switch_text")
+        bestSwitch?.isChecked =
+            sharedPref?.getBoolean(AnimeUnityPlugin.PREF_SHOW_BEST, true) ?: true
+
+        val upcomingSwitch: Switch? = view.findViewByName("upcoming_switch")
+        upcomingSwitch?.text = getString("upcoming_switch_text")
+        upcomingSwitch?.isChecked =
+            sharedPref?.getBoolean(AnimeUnityPlugin.PREF_SHOW_UPCOMING, true) ?: true
+
+        val scoreSwitch: Switch? = view.findViewByName("score_switch")
+        scoreSwitch?.text = getString("score_switch_text")
+        scoreSwitch?.isChecked =
+            sharedPref?.getBoolean(AnimeUnityPlugin.PREF_SHOW_SCORE, true) ?: true
+
+        val saveBtn: ImageButton? = view.findViewByName("save_btn")
+        saveBtn?.makeTvCompatible()
+        saveBtn?.setImageDrawable(getDrawable("save_icon"))
+        saveBtn?.setOnClickListener {
+            sharedPref?.edit {
+                putBoolean(
+                    AnimeUnityPlugin.PREF_SHOW_LATEST_EPISODES,
+                    latestEpisodesSwitch?.isChecked ?: true
+                )
+                putBoolean(
+                    AnimeUnityPlugin.PREF_SHOW_CALENDAR,
+                    calendarSwitch?.isChecked ?: true
+                )
+                putBoolean(
+                    AnimeUnityPlugin.PREF_SHOW_ONGOING,
+                    ongoingSwitch?.isChecked ?: true
+                )
+                putBoolean(
+                    AnimeUnityPlugin.PREF_SHOW_POPULAR,
+                    popularSwitch?.isChecked ?: true
+                )
+                putBoolean(
+                    AnimeUnityPlugin.PREF_SHOW_BEST,
+                    bestSwitch?.isChecked ?: true
+                )
+                putBoolean(
+                    AnimeUnityPlugin.PREF_SHOW_UPCOMING,
+                    upcomingSwitch?.isChecked ?: true
+                )
+                putBoolean(
+                    AnimeUnityPlugin.PREF_SHOW_SCORE,
+                    scoreSwitch?.isChecked ?: true
+                )
+            }
+
+            showToast(
+                getString("settings_saved")
+                    ?: "Impostazioni salvate. Riavvia l'applicazione per applicarle"
+            )
+            dismiss()
+        }
+    }
+}

--- a/AnimeUnity/src/main/res/drawable/outline.xml
+++ b/AnimeUnity/src/main/res/drawable/outline.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true">
+        <shape>
+            <stroke
+                android:width="2dp"
+                android:color="#FFF" />
+            <corners
+                android:bottomLeftRadius="6dp"
+                android:bottomRightRadius="6dp"
+                android:topLeftRadius="6dp"
+                android:topRightRadius="6dp" />
+        </shape>
+    </item>
+    <item android:state_hovered="true">
+        <shape>
+            <solid android:color="#99FFFFFF" />
+        </shape>
+    </item>
+</selector>

--- a/AnimeUnity/src/main/res/drawable/save_icon.xml
+++ b/AnimeUnity/src/main/res/drawable/save_icon.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@android:color/white">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M21,12.4V7l-4,-4H5C3.89,3 3,3.9 3,5v14c0,1.1 0.89,2 2,2h7.4L21,12.4zM15,15c0,1.66 -1.34,3 -3,3s-3,-1.34 -3,-3s1.34,-3 3,-3S15,13.34 15,15zM6,6h9v4H6V6zM19.99,16.25l1.77,1.77L16.77,23H15v-1.77L19.99,16.25zM23.25,16.51l-0.85,0.85l-1.77,-1.77l0.85,-0.85c0.2,-0.2 0.51,-0.2 0.71,0l1.06,1.06C23.45,16 23.45,16.32 23.25,16.51z" />
+</vector>

--- a/AnimeUnity/src/main/res/layout/settings.xml
+++ b/AnimeUnity/src/main/res/layout/settings.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    tools:context=".AnimeUnitySettings">
+
+    <LinearLayout
+        android:id="@+id/settingsLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:orientation="vertical"
+        android:padding="8dp">
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="48dp">
+
+            <TextView
+                android:id="@+id/header_tw"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentStart="true"
+                android:layout_centerVertical="true"
+                android:text="@string/header_tw"
+                android:textSize="24sp"
+                android:textStyle="bold" />
+
+            <ImageButton
+                android:id="@+id/save_btn"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:layout_alignParentEnd="true"
+                android:layout_centerVertical="true"
+                android:background="@android:color/transparent"
+                android:contentDescription="Salva impostazioni" />
+        </RelativeLayout>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="12dp"
+            android:background="@android:color/transparent" />
+
+        <TextView
+            android:id="@+id/sections_label"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/sections_label"
+            android:textStyle="bold" />
+
+        <Switch
+            android:id="@+id/latest_episodes_switch"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:text="@string/latest_episodes_switch_text"
+            android:textSize="16sp" />
+
+        <Switch
+            android:id="@+id/calendar_switch"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:text="@string/calendar_switch_text"
+            android:textSize="16sp" />
+
+        <Switch
+            android:id="@+id/ongoing_switch"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:text="@string/ongoing_switch_text"
+            android:textSize="16sp" />
+
+        <Switch
+            android:id="@+id/popular_switch"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:text="@string/popular_switch_text"
+            android:textSize="16sp" />
+
+        <Switch
+            android:id="@+id/best_switch"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:text="@string/best_switch_text"
+            android:textSize="16sp" />
+
+        <Switch
+            android:id="@+id/upcoming_switch"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:text="@string/upcoming_switch_text"
+            android:textSize="16sp" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="12dp"
+            android:background="@android:color/transparent" />
+
+        <TextView
+            android:id="@+id/display_label"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/display_label"
+            android:textStyle="bold" />
+
+        <Switch
+            android:id="@+id/score_switch"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:text="@string/score_switch_text"
+            android:textSize="16sp" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="16dp"
+            android:background="@android:color/transparent" />
+
+    </LinearLayout>
+</ScrollView>

--- a/AnimeUnity/src/main/res/values/strings.xml
+++ b/AnimeUnity/src/main/res/values/strings.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="header_tw">Impostazioni AnimeUnity</string>
+    <string name="sections_label">Sezioni della home</string>
+    <string name="latest_episodes_switch_text">Ultimi Episodi</string>
+    <string name="calendar_switch_text">Calendario</string>
+    <string name="ongoing_switch_text">In Corso</string>
+    <string name="popular_switch_text">Popolari</string>
+    <string name="best_switch_text">I migliori</string>
+    <string name="upcoming_switch_text">In Arrivo</string>
+    <string name="display_label">Visualizzazione</string>
+    <string name="score_switch_text">Mostra valutazione</string>
+    <string name="settings_saved">Impostazioni salvate. Riavvia l\'applicazione per applicarle</string>
+</resources>


### PR DESCRIPTION
1. Aggiunte due nuove sezioni per AnimeUnity:
- Ultimi Episodi: mostra gli ultimi episodi pubblicati su AnimeUnity
- Calendario: mostra gli episodi previsti per il giorno corrente

2. Aggiunta la visualizzazione della valutazione, recuperata direttamente da AnimeUnity

3. Possibilità per l'utente di scegliere quali sezioni mostrare nella Home e se visualizzare la valutazione
