### PR TITLE
AnimeUnity: Miglioramenti

### DIFF
--- a/AnimeUnity/build.gradle.kts
+++ b/AnimeUnity/build.gradle.kts
@@ -1,5 +1,5 @@
 // use an integer for version numbers
-version = 17
+version = 18
 
 
 cloudstream {

--- a/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnity.kt
+++ b/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnity.kt
@@ -1,7 +1,6 @@
 package it.dogior.hadEnough
 
 import android.content.SharedPreferences
-import com.lagradost.api.Log
 import com.lagradost.cloudstream3.DubStatus
 import com.lagradost.cloudstream3.HomePageList
 import com.lagradost.cloudstream3.HomePageResponse
@@ -11,8 +10,10 @@ import com.lagradost.cloudstream3.LoadResponse.Companion.addDuration
 import com.lagradost.cloudstream3.LoadResponse.Companion.addMalId
 import com.lagradost.cloudstream3.LoadResponse.Companion.addScore
 import com.lagradost.cloudstream3.MainAPI
+import com.lagradost.cloudstream3.MainPageData
 import com.lagradost.cloudstream3.MainPageRequest
 import com.lagradost.cloudstream3.Score
+import com.lagradost.cloudstream3.AnimeSearchResponse
 import com.lagradost.cloudstream3.SearchResponse
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.TvType
@@ -29,20 +30,23 @@ import com.lagradost.cloudstream3.newHomePageResponse
 import com.lagradost.cloudstream3.utils.AppUtils.parseJson
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.jsoup.nodes.Element
 import java.text.Normalizer
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
 typealias Str = BooleanOrString.AsString
-//typealias Bool = BooleanOrString.AsBoolean
 
-const val TAG = "AnimeUnity"
-
+@Suppress("unused")
 class AnimeUnity(
     private val sharedPref: SharedPreferences?,
 ) : MainAPI() {
-    override var mainUrl = Companion.mainUrl
+    override var mainUrl = AnimeUnityPlugin.getConfiguredBaseUrl(sharedPref)
+        get() = AnimeUnityPlugin.getConfiguredBaseUrl(sharedPref)
+        set(value) {
+            field = value
+        }
     override var name = Companion.name
     override var supportedTypes = setOf(TvType.Anime, TvType.AnimeMovie, TvType.OVA)
     override var lang = "it"
@@ -51,50 +55,131 @@ class AnimeUnity(
     companion object {
         @Suppress("ConstPropertyName")
         const val mainUrl = "https://www.animeunity.so"
+        const val ARCHIVE_BATCH_SIZE = 30
         const val latestEpisodesSectionName = "Ultimi Episodi"
         const val calendarSectionName = "Calendario"
+        const val randomSectionName = "Random"
+        const val ongoingSectionName = "In Corso"
+        const val popularSectionName = "Popolari"
+        const val bestSectionName = "I migliori"
+        const val upcomingSectionName = "In Arrivo"
+        
         var name = "AnimeUnity"
         var headers = mapOf(
             "Host" to mainUrl.toHttpUrl().host,
             "User-Agent" to "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0"
         ).toMutableMap()
-//        var cookies = emptyMap<String, String>()
     }
 
-    private val sectionNamesList = buildSectionNamesList()
-    override val mainPage = sectionNamesList
-
-    private fun buildSectionNamesList() = mainPageOf(
-        *buildList {
-            if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_LATEST_EPISODES)) {
-                add("$mainUrl/" to latestEpisodesSectionName)
-            }
-            if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_CALENDAR)) {
-                add("$mainUrl/calendario" to calendarSectionName)
-            }
-            if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_ONGOING)) {
-                add("$mainUrl/archivio/" to "In Corso")
-            }
-            if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_POPULAR)) {
-                add("$mainUrl/archivio/" to "Popolari")
-            }
-            if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_BEST)) {
-                add("$mainUrl/archivio/" to "I migliori")
-            }
-            if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_UPCOMING)) {
-                add("$mainUrl/archivio/" to "In Arrivo")
-            }
-        }.toTypedArray()
+    private data class ArchivePageResult(
+        val titles: List<Anime>,
+        val hasNextPage: Boolean,
     )
+
+    override val mainPage: List<MainPageData>
+        get() = buildSectionNamesList()
+
+    private fun buildSectionNamesList(): List<MainPageData> {
+        val order = AnimeUnityPlugin.getConfiguredSectionOrder(sharedPref)
+        val sections = order.split(",")
+        
+        return mainPageOf(
+            *sections.mapNotNull { section ->
+                when (section) {
+                    "latest" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_LATEST_EPISODES)) "$mainUrl/" to latestEpisodesSectionName else null
+                    "calendar" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_CALENDAR)) "$mainUrl/calendario" to calendarSectionName else null
+                    "ongoing" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_ONGOING)) "$mainUrl/archivio/" to ongoingSectionName else null
+                    "popular" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_POPULAR)) "$mainUrl/archivio/" to popularSectionName else null
+                    "best" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_BEST)) "$mainUrl/archivio/" to bestSectionName else null
+                    "upcoming" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_UPCOMING)) "$mainUrl/archivio/" to upcomingSectionName else null
+                    "random" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_RANDOM)) "$mainUrl/archivio/" to randomSectionName else null
+                    else -> null
+                }
+            }.toTypedArray()
+        )
+    }
 
     private fun isSectionEnabled(prefKey: String): Boolean {
         return sharedPref?.getBoolean(prefKey, true) ?: true
+    }
+
+    private fun getSectionCount(sectionName: String): Int {
+        val key = when (sectionName) {
+            latestEpisodesSectionName -> AnimeUnityPlugin.PREF_LATEST_COUNT
+            calendarSectionName -> AnimeUnityPlugin.PREF_CALENDAR_COUNT
+            ongoingSectionName -> AnimeUnityPlugin.PREF_ONGOING_COUNT
+            popularSectionName -> AnimeUnityPlugin.PREF_POPULAR_COUNT
+            bestSectionName -> AnimeUnityPlugin.PREF_BEST_COUNT
+            upcomingSectionName -> AnimeUnityPlugin.PREF_UPCOMING_COUNT
+            randomSectionName -> AnimeUnityPlugin.PREF_RANDOM_COUNT
+            else -> return AnimeUnityPlugin.DEFAULT_SECTION_COUNT
+        }
+        return (sharedPref?.getInt(key, AnimeUnityPlugin.DEFAULT_SECTION_COUNT)
+            ?: AnimeUnityPlugin.DEFAULT_SECTION_COUNT).coerceIn(1, AnimeUnityPlugin.MAX_SECTION_COUNT)
     }
 
     private fun shouldShowScore(): Boolean {
         return sharedPref?.getBoolean(AnimeUnityPlugin.PREF_SHOW_SCORE, true) ?: true
     }
 
+    private fun shouldShowDubSub(): Boolean {
+        return sharedPref?.getBoolean(AnimeUnityPlugin.PREF_SHOW_DUB_SUB, true) ?: true
+    }
+
+    private fun shouldShowEpisodeNumber(): Boolean {
+        return sharedPref?.getBoolean(AnimeUnityPlugin.PREF_SHOW_EPISODE_NUMBER, true) ?: true
+    }
+
+    private fun withoutDubSuffix(title: String): String {
+        return title.replace(" (ITA)", "")
+    }
+
+    private fun buildDisplayTitle(title: String, episodeNumber: Int?): String {
+        val baseTitle = withoutDubSuffix(title)
+
+        return if (!shouldShowDubSub() && shouldShowEpisodeNumber() && episodeNumber != null) {
+            "$baseTitle - Ep. $episodeNumber"
+        } else {
+            baseTitle
+        }
+    }
+
+    private fun applyCardDisplayState(
+        response: AnimeSearchResponse,
+        dubbed: Boolean,
+        poster: String?,
+        score: String?,
+        episodeNumber: Int? = null,
+    ) {
+        if (shouldShowDubSub()) {
+            if (shouldShowEpisodeNumber()) {
+                response.addDubStatus(dubbed, episodeNumber)
+            } else {
+                response.addDubStatus(dubbed)
+            }
+        }
+
+        response.addPoster(poster)
+
+        if (shouldShowScore()) {
+            score?.let {
+                response.score = Score.from(it, 10)
+            }
+        }
+    }
+
+    private suspend fun ensureHeadersAndCookies(forceReset: Boolean = false) {
+        val currentHost = mainUrl.toHttpUrl().host
+        val shouldRefreshHeaders = forceReset ||
+            headers["Host"] != currentHost ||
+            headers["Referer"] != mainUrl ||
+            !headers.containsKey("Cookie")
+
+        if (shouldRefreshHeaders) {
+            resetHeadersAndCookies()
+            setupHeadersAndCookies()
+        }
+    }
 
     private suspend fun setupHeadersAndCookies() {
         val response = app.get("$mainUrl/archivio", headers = headers)
@@ -110,28 +195,24 @@ class AnimeUnity(
             "Cookie" to cookies
         )
         headers.putAll(h)
-//        // Log.d("$TAG:setup", "Headers: $headers")
-
     }
 
     private fun resetHeadersAndCookies() {
         if (headers.isNotEmpty()) {
             headers.clear()
         }
-        headers["Host"] = Companion.mainUrl.toHttpUrl().host
+        headers["Host"] = mainUrl.toHttpUrl().host
         headers["User-Agent"] =
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0"
-//        cookies = emptyMap()
     }
 
-    private suspend fun searchResponseBuilder(objectList: List<Anime>): List<SearchResponse> {
+    private suspend fun searchResponseBuilder(objectList: List<Anime>, episodeNumber: Int? = null): List<SearchResponse> {
         return objectList.amap { anime ->
             val title = (anime.titleIt ?: anime.titleEng ?: anime.title!!)
-
             val poster = getImage(anime.imageUrl, anime.anilistId)
 
             newAnimeSearchResponse(
-                name = title.replace(" (ITA)", ""),
+                name = buildDisplayTitle(title, episodeNumber),
                 url = "$mainUrl/anime/${anime.id}-${anime.slug}",
                 type = when {
                     anime.type == "TV" -> TvType.Anime
@@ -139,14 +220,91 @@ class AnimeUnity(
                     else -> TvType.OVA
                 }
             ).apply {
-                addDubStatus(anime.dub == 1 || title.contains("(ITA)"))
-                addPoster(poster)
-                if (shouldShowScore()) {
-                    this.score = Score.from(anime.score, 10)
-                }
+                applyCardDisplayState(
+                    response = this,
+                    dubbed = anime.dub == 1 || title.contains("(ITA)"),
+                    poster = poster,
+                    score = anime.score,
+                    episodeNumber = episodeNumber
+                )
+            }
+        }
+    }
+
+    private suspend fun fetchArchiveBatch(url: String, requestData: RequestData): ApiResponse {
+        val response = app.post(url, headers = headers, requestBody = requestData.toRequestBody())
+        return parseJson<ApiResponse>(response.text)
+    }
+
+    private suspend fun fetchArchiveSectionPage(
+        url: String,
+        requestData: RequestData,
+        page: Int,
+        sectionCount: Int,
+    ): ArchivePageResult {
+        val pageStartOffset = (page - 1) * sectionCount
+        val collectedTitles = mutableListOf<Anime>()
+        var nextOffset = pageStartOffset
+        var total = 0
+
+        while (collectedTitles.size < sectionCount) {
+            val responseObject = fetchArchiveBatch(url, requestData.copy(offset = nextOffset))
+            total = responseObject.total
+
+            val batchTitles = responseObject.titles.orEmpty()
+            if (batchTitles.isEmpty()) break
+
+            collectedTitles += batchTitles.take(sectionCount - collectedTitles.size)
+            nextOffset += batchTitles.size
+
+            if (nextOffset >= total || batchTitles.size < ARCHIVE_BATCH_SIZE) {
+                break
+            }
+        }
+
+        return ArchivePageResult(
+            titles = collectedTitles,
+            hasNextPage = total > pageStartOffset + collectedTitles.size,
+        )
+    }
+
+    private suspend fun fetchRandomTitles(url: String, sectionCount: Int): Pair<List<Anime>, Int> {
+        val initialResponse = fetchArchiveBatch(url, RequestData(offset = 0))
+        val total = initialResponse.total
+        val collectedTitles = linkedMapOf<Int, Anime>()
+        val requestedOffsets = mutableSetOf<Int>()
+        val maxAttempts = ((sectionCount + ARCHIVE_BATCH_SIZE - 1) / ARCHIVE_BATCH_SIZE) * 3
+
+        fun collectBatch(batch: List<Anime>) {
+            batch.forEach { anime ->
+                collectedTitles.putIfAbsent(anime.id, anime)
+            }
+        }
+
+        if (total <= ARCHIVE_BATCH_SIZE) {
+            collectBatch(initialResponse.titles.orEmpty())
+            return collectedTitles.values.shuffled().take(sectionCount) to total
+        }
+
+        repeat(maxAttempts) {
+            if (collectedTitles.size >= sectionCount) {
+                return@repeat
             }
 
+            val maxOffset = (total - ARCHIVE_BATCH_SIZE).coerceAtLeast(0)
+            val randomOffset = if (maxOffset == 0) 0 else (0..maxOffset).random()
+            if (!requestedOffsets.add(randomOffset)) {
+                return@repeat
+            }
+
+            collectBatch(fetchArchiveBatch(url, RequestData(offset = randomOffset)).titles.orEmpty())
         }
+
+        if (collectedTitles.isEmpty()) {
+            collectBatch(initialResponse.titles.orEmpty())
+        }
+
+        return collectedTitles.values.shuffled().take(sectionCount) to total
     }
 
     private suspend fun latestEpisodesResponseBuilder(objectList: List<LatestEpisodeItem>): List<SearchResponse> {
@@ -156,7 +314,7 @@ class AnimeUnity(
             val poster = getImage(anime.imageUrl, anime.anilistId)
 
             newAnimeSearchResponse(
-                name = title.replace(" (ITA)", ""),
+                name = buildDisplayTitle(title, item.number.toIntOrNull()),
                 url = "$mainUrl/anime/${anime.id}-${anime.slug}",
                 type = when {
                     anime.type == "TV" -> TvType.Anime
@@ -164,28 +322,34 @@ class AnimeUnity(
                     else -> TvType.OVA
                 }
             ).apply {
-                addDubStatus(anime.dub == 1 || title.contains("(ITA)"), item.number.toIntOrNull())
-                addPoster(poster)
-                if (shouldShowScore()) {
-                    this.score = Score.from(anime.score, 10)
-                }
+                applyCardDisplayState(
+                    response = this,
+                    dubbed = anime.dub == 1 || title.contains("(ITA)"),
+                    poster = poster,
+                    score = anime.score,
+                    episodeNumber = item.number.toIntOrNull()
+                )
             }
         }
     }
 
+    private fun getImageCdnHost(): String {
+        val host = mainUrl.toHttpUrl().host
+        return when {
+            host == "animeunity.so" -> "img.animeunity.so"
+            host.startsWith("www.") -> host.replaceFirst("www.", "img.")
+            host.startsWith("img.") -> host
+            else -> "img.$host"
+        }
+    }
+
     private suspend fun getImage(imageUrl: String?, anilistId: Int?): String? {
-        // First try the direct image URL if available
         if (!imageUrl.isNullOrEmpty()) {
             try {
                 val fileName = imageUrl.substringAfterLast("/")
-                return "https://img.animeunity.so/anime/$fileName"
-            } catch (_: Exception) {
-                // Fallback to Anilist if direct image fails
-            }
+                return "https://${getImageCdnHost()}/anime/$fileName"
+            } catch (_: Exception) {}
         }
-
-        // Fallback to Anilist
-
         return anilistId?.let { getAnilistPoster(it) }
     }
 
@@ -201,77 +365,51 @@ class AnimeUnity(
         }
     """.trimIndent()
 
-        val body = mapOf(
-            "query" to query,
-            "variables" to """{"id":$anilistId}"""
-        )
+        val body = mapOf("query" to query, "variables" to """{"id":$anilistId}""")
         val response = app.post("https://graphql.anilist.co", data = body)
         val anilistObj = parseJson<AnilistResponse>(response.text)
 
         return anilistObj.data.media.coverImage?.let { coverImage ->
             coverImage.large ?: coverImage.medium!!
         } ?: throw IllegalStateException("No valid image found")
-
     }
 
-    //Get the Homepage
     override suspend fun getMainPage(page: Int, request: MainPageRequest): HomePageResponse {
-//        val localTag = "$TAG:MainPage"
         if (request.name == latestEpisodesSectionName) {
             return getLatestEpisodesMainPage(page)
         }
-        if (request.name == calendarSectionName) {
+        if (request.name.startsWith(calendarSectionName)) {
             return getCalendarMainPage(page, request)
+        }
+        if (request.name == randomSectionName) {
+            return getRandomMainPage(page)
         }
 
         val url = request.data + "get-animes"
-        if (!headers.contains("Cookie")) {
-            resetHeadersAndCookies()
-            setupHeadersAndCookies()
-        }
+        ensureHeadersAndCookies()
 
         val requestData = getDataPerHomeSection(request.name)
-
-        val offset = (page - 1) * 30
-        requestData.offset = offset
-
-        // Log.d(
-//            localTag,
-//            "Sezione: ${request.name} \tPage: $page \t Offset: $offset \t Request offset: ${requestData.offset}"
-//        )
-        val requestBody = requestData.toRequestBody()
-
-
-        val response =
-            app.post(url, headers = headers, requestBody = requestBody)
-
-        val body = response.text
-//        Log.d("$TAG:body", body)
-
-//        // Log.d(localTag, "Cookies: ${response.cookies}")
-        val responseObject = parseJson<ApiResponse>(body)
-        val titles = responseObject.titles
-//        // Log.d(localTag, "Titles: $titles")
-
-        val hasNextPage = requestData.offset
-            ?.let { it < 177 } ?: true && titles?.size == 30
+        val sectionCount = getSectionCount(request.name)
+        val archivePage = fetchArchiveSectionPage(url, requestData, page, sectionCount)
         return newHomePageResponse(
             HomePageList(
                 name = request.name,
-                list = titles?.let { searchResponseBuilder(it) } ?: emptyList(),
+                list = if (archivePage.titles.isNotEmpty()) {
+                    searchResponseBuilder(archivePage.titles)
+                } else {
+                    emptyList()
+                },
                 isHorizontalImages = false
-            ), hasNextPage
+            ),
+            archivePage.hasNextPage
         )
     }
 
     private suspend fun getLatestEpisodesMainPage(page: Int): HomePageResponse {
+        val sectionCount = getSectionCount(latestEpisodesSectionName)
         if (page > 1) {
             return newHomePageResponse(
-                HomePageList(
-                    name = latestEpisodesSectionName,
-                    list = emptyList(),
-                    isHorizontalImages = false
-                ),
+                HomePageList(name = latestEpisodesSectionName, list = emptyList(), isHorizontalImages = false),
                 false
             )
         }
@@ -286,6 +424,7 @@ class AnimeUnity(
             ?.let { json ->
                 runCatching { parseJson<LatestEpisodesPage>(json).episodes }.getOrDefault(emptyList())
             }
+            ?.take(sectionCount)
             ?: emptyList()
 
         return newHomePageResponse(
@@ -298,20 +437,14 @@ class AnimeUnity(
         )
     }
 
-    private suspend fun getCalendarMainPage(
-        page: Int,
-        request: MainPageRequest,
-    ): HomePageResponse {
+    private suspend fun getCalendarMainPage(page: Int, request: MainPageRequest): HomePageResponse {
         val currentDay = getCurrentItalianDayName()
         val calendarTitle = "$calendarSectionName ($currentDay)"
+        val sectionCount = getSectionCount(calendarSectionName)
 
         if (page > 1) {
             return newHomePageResponse(
-                HomePageList(
-                    name = calendarTitle,
-                    list = emptyList(),
-                    isHorizontalImages = false
-                ),
+                HomePageList(name = calendarTitle, list = emptyList(), isHorizontalImages = false),
                 false
             )
         }
@@ -319,22 +452,61 @@ class AnimeUnity(
         val calendarAnime = app.get(request.data).document
             .select("calendario-item")
             .mapNotNull { item ->
-                item.attr("a")
-                    .takeIf(String::isNotBlank)
-                    ?.let { animeJson ->
-                        runCatching { parseJson<Anime>(animeJson) }.getOrNull()
-                    }
+                val animeJson = item.attr("a")
+                if (animeJson.isBlank()) return@mapNotNull null
+
+                val anime = runCatching { parseJson<Anime>(animeJson) }.getOrNull() ?: return@mapNotNull null
+                val episodeNumber = extractCalendarEpisodeNumber(item, anime)
+
+                if (normalizeDayName(anime.day) == normalizeDayName(currentDay)) {
+                    anime to episodeNumber
+                } else {
+                    null
+                }
             }
-            .filter { normalizeDayName(it.day) == normalizeDayName(currentDay) }
-            .distinctBy { it.id }
+            .distinctBy { it.first.id }
+            .take(sectionCount)
 
         return newHomePageResponse(
             HomePageList(
                 name = calendarTitle,
-                list = searchResponseBuilder(calendarAnime),
+                list = calendarAnime.amap { (anime, ep) ->
+                    searchResponseBuilder(listOf(anime), ep).first()
+                },
                 isHorizontalImages = false
             ),
             false
+        )
+    }
+
+    private fun extractCalendarEpisodeNumber(item: Element, anime: Anime): Int? {
+        item.attr("episodes_count")
+            .trim()
+            .toIntOrNull()
+            ?.let { releasedEpisodes ->
+                return releasedEpisodes + 1
+            }
+
+        return anime.episodes
+            ?.mapNotNull { it.number.toIntOrNull() }
+            ?.maxOrNull()
+            ?.plus(1)
+    }
+
+    private suspend fun getRandomMainPage(page: Int): HomePageResponse {
+        val url = "$mainUrl/archivio/get-animes"
+        ensureHeadersAndCookies()
+
+        val sectionCount = getSectionCount(randomSectionName)
+        val (titles, total) = fetchRandomTitles(url, sectionCount)
+
+        return newHomePageResponse(
+            HomePageList(
+                name = randomSectionName,
+                list = searchResponseBuilder(titles),
+                isHorizontalImages = false
+            ),
+            page < 5 && total > sectionCount
         )
     }
 
@@ -353,93 +525,53 @@ class AnimeUnity(
     }
 
     private fun getDataPerHomeSection(section: String) = when (section) {
-        "Popolari" -> {
-            RequestData(orderBy = Str("Popolarità"), dubbed = 0)
-        }
-
-        "In Arrivo" -> {
-            RequestData(status = Str("In Uscita"), dubbed = 0)
-        }
-
-        "I migliori" -> {
-            RequestData(orderBy = Str("Valutazione"), dubbed = 0)
-        }
-
-        "In Corso" -> {
-            RequestData(orderBy = Str("Popolarità"), status = Str("In Corso"), dubbed = 0)
-        }
-
-        else -> {
-            RequestData()
-        }
+        popularSectionName -> RequestData(orderBy = Str("Popolarità"), dubbed = 0)
+        upcomingSectionName -> RequestData(status = Str("In Uscita"), dubbed = 0)
+        bestSectionName -> RequestData(orderBy = Str("Valutazione"), dubbed = 0)
+        ongoingSectionName -> RequestData(orderBy = Str("Popolarità"), status = Str("In Corso"), dubbed = 0)
+        else -> RequestData()
     }
-
 
     override suspend fun search(query: String): List<SearchResponse> {
-//        val localTag = "$TAG:search"
         val url = "$mainUrl/archivio/get-animes"
-
-        resetHeadersAndCookies()
-        setupHeadersAndCookies()
+        ensureHeadersAndCookies(forceReset = true)
 
         val requestBody = RequestData(title = query, dubbed = 0).toRequestBody()
-        val response =
-            app.post(url, headers = headers, requestBody = requestBody)
+        val response = app.post(url, headers = headers, requestBody = requestBody)
 
         val responseObject = parseJson<ApiResponse>(response.text)
-        val titles = responseObject.titles
-        // Log.d(localTag, "Titles: $titles")
+        val titles = responseObject.titles ?: emptyList()
 
-        return searchResponseBuilder(titles ?: emptyList())
+        return searchResponseBuilder(titles)
     }
 
-    // This function gets called when you enter the page/show
     override suspend fun load(url: String): LoadResponse {
-//        val localTag = "$TAG:load"
-        resetHeadersAndCookies()
-        setupHeadersAndCookies()
+        ensureHeadersAndCookies(forceReset = true)
         val animePage = app.get(url).document
 
-        val relatedAnimeJsonArray =
-            animePage.select("layout-items").attr("items-json")//.replace("\\", "")
+        val relatedAnimeJsonArray = animePage.select("layout-items").attr("items-json")
         val relatedAnime = parseJson<List<Anime>>(relatedAnimeJsonArray)
-
 
         val videoPlayer = animePage.select("video-player")
         val anime = parseJson<Anime>(videoPlayer.attr("anime"))
 
-
         val eps = parseJson<List<Episode>>(videoPlayer.attr("episodes"))
         val totalEps = videoPlayer.attr("episodes_count").toInt()
-        // 120 is the max number of episodes per request to the info_api endpoint
         val isEpNumberMultipleOfRange = totalEps % 120 == 0
-        val range = if (isEpNumberMultipleOfRange) {
-            totalEps / 120
-        } else {
-            (totalEps / 120) + 1
-        }
+        val range = if (isEpNumberMultipleOfRange) totalEps / 120 else (totalEps / 120) + 1
+        
         val episodes = eps.map {
-            newEpisode("$url/${it.id}") {
-                this.episode = it.number.toIntOrNull()
-            }
+            newEpisode("$url/${it.id}") { this.episode = it.number.toIntOrNull() }
         }.toMutableList()
 
         if (totalEps > 120) {
             for (i in 2..range) {
-                val endRange = if (i == range) {
-                    totalEps
-                } else {
-                    i * 120
-                }
-
-                val infoUrl =
-                    "$mainUrl/info_api/${anime.id}/1?start_range=${1 + (i - 1) * 120}&end_range=${endRange}"
+                val endRange = if (i == range) totalEps else i * 120
+                val infoUrl = "$mainUrl/info_api/${anime.id}/1?start_range=${1 + (i - 1) * 120}&end_range=${endRange}"
                 val info = app.get(infoUrl).text
                 val animeInfo = parseJson<AnimeInfo>(info)
                 episodes.addAll(animeInfo.episodes.map {
-                    newEpisode("$url/${it.id}") {
-                        this.episode = it.number.toIntOrNull()
-                    }
+                    newEpisode("$url/${it.id}") { this.episode = it.number.toIntOrNull() }
                 })
             }
         }
@@ -448,84 +580,63 @@ class AnimeUnity(
             val relatedTitle = (it.titleIt ?: it.titleEng ?: it.title!!)
             val poster = getImage(it.imageUrl, it.anilistId)
             newAnimeSearchResponse(
-                name = relatedTitle.replace(" (ITA)", ""),
+                name = withoutDubSuffix(relatedTitle),
                 url = "$mainUrl/anime/${it.id}-${it.slug}",
                 type = if (it.type == "TV") TvType.Anime
                 else if (it.type == "Movie" || it.episodesCount == 1) TvType.AnimeMovie
                 else TvType.OVA
             ) {
-                addDubStatus(it.dub == 1 || relatedTitle.contains("(ITA)"))
+                if (shouldShowDubSub()) {
+                    addDubStatus(it.dub == 1 || relatedTitle.contains("(ITA)"))
+                }
                 addPoster(poster)
             }
         }
 
-        val animeLoadResponse = newAnimeLoadResponse(
+        return newAnimeLoadResponse(
             name = title.replace(" (ITA)", ""),
             url = url,
             type = if (anime.type == "TV") TvType.Anime
             else if (anime.type == "Movie" || anime.episodesCount == 1) TvType.AnimeMovie
             else TvType.OVA,
         ) {
-            this.posterUrl =
-                getImage(anime.imageUrl, anime.anilistId)
-            anime.cover?.let {
-                this.backgroundPosterUrl = getBanner(it)
-            }
+            this.posterUrl = getImage(anime.imageUrl, anime.anilistId)
+            anime.cover?.let { this.backgroundPosterUrl = getBanner(it) }
             this.year = anime.date.toInt()
             addScore(anime.score)
-
             addDuration(anime.episodesLength.toString() + " minuti")
             val dub = if (anime.dub == 1) DubStatus.Dubbed else DubStatus.Subbed
             addEpisodes(dub, episodes)
-
             addAniListId(anime.anilistId)
             addMalId(anime.malId)
             this.plot = anime.plot
-            val doppiato =
-                if (anime.dub == 1 || title.contains("(ITA)")) "\uD83C\uDDEE\uD83C\uDDF9  Italiano" else "\uD83C\uDDEF\uD83C\uDDF5  Giapponese"
+            val doppiato = if (anime.dub == 1 || title.contains("(ITA)")) "\uD83C\uDDEE\uD83C\uDDF9  Italiano" else "\uD83C\uDDEF\uD83C\uDDF5  Giapponese"
             this.tags = listOf(doppiato) + anime.genres.map { genre ->
-                genre.name.replaceFirstChar {
-                    if (it.isLowerCase()) it.titlecase(
-                        Locale.getDefault()
-                    ) else it.toString()
-                }
+                genre.name.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
             }
             this.comingSoon = anime.status == "In uscita prossimamente"
             this.recommendations = relatedAnimes
         }
-
-        return animeLoadResponse
     }
 
     private fun getBanner(imageUrl: String): String {
-//        Log.d("$TAG:getPoster", "imageUrl: $imageUrl")
         if (imageUrl.isNotEmpty()) {
             try {
                 val fileName = imageUrl.substringAfterLast("/")
-                val cdnHost = mainUrl.toHttpUrl().host.replace("www", "img")
-                return "https://$cdnHost/anime/$fileName"
-            } catch (_: Exception) {
-            }
+                return "https://${getImageCdnHost()}/anime/$fileName"
+            } catch (_: Exception) {}
         }
         return imageUrl
     }
 
-
-    // This function is how you load the links
     override suspend fun loadLinks(
         data: String,
         isCasting: Boolean,
         subtitleCallback: (SubtitleFile) -> Unit,
         callback: (ExtractorLink) -> Unit,
     ): Boolean {
-//        val localTag = "$TAG:loadLinks"
-//         Log.d(localTag, "Url : $data")
-
         val document = app.get(data).document
-
         val sourceUrl = document.select("video-player").attr("embed_url")
-//         Log.d(localTag, "Document: $document")
-//         Log.d(localTag, "Iframe: $sourceUrl")
         VixCloudExtractor().getUrl(
             url = sourceUrl,
             referer = mainUrl,

--- a/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnityPlugin.kt
+++ b/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnityPlugin.kt
@@ -5,30 +5,132 @@ import android.content.SharedPreferences
 import androidx.appcompat.app.AppCompatActivity
 import com.lagradost.cloudstream3.plugins.CloudstreamPlugin
 import com.lagradost.cloudstream3.plugins.Plugin
+import java.util.Locale
 
 @CloudstreamPlugin
 class AnimeUnityPlugin : Plugin() {
     companion object {
         const val PREFS_NAME = "AnimeUnity"
+        const val PREF_SITE_URL = "siteUrl"
+        
+        // Sezioni abilitate
         const val PREF_SHOW_LATEST_EPISODES = "showLatestEpisodes"
         const val PREF_SHOW_CALENDAR = "showCalendar"
+        const val PREF_SHOW_RANDOM = "showRandom"
         const val PREF_SHOW_ONGOING = "showOngoing"
         const val PREF_SHOW_POPULAR = "showPopular"
         const val PREF_SHOW_BEST = "showBest"
         const val PREF_SHOW_UPCOMING = "showUpcoming"
+        
+        // Count per sezione
+        const val PREF_LATEST_COUNT = "latestCount"
+        const val PREF_CALENDAR_COUNT = "calendarCount"
+        const val PREF_ONGOING_COUNT = "ongoingCount"
+        const val PREF_POPULAR_COUNT = "popularCount"
+        const val PREF_BEST_COUNT = "bestCount"
+        const val PREF_UPCOMING_COUNT = "upcomingCount"
+        const val PREF_RANDOM_COUNT = "randomCount"
+
+        // Visualizzazione
+        const val PREF_SHOW_DUB_SUB = "showDubSub"
+        const val PREF_SHOW_EPISODE_NUMBER = "showEpisodeNumber"
         const val PREF_SHOW_SCORE = "showScore"
+
+        const val PREF_SECTION_ORDER = "sectionOrder"
+
+        const val DEFAULT_SITE_URL = "https://www.animeunity.so/"
+        const val DEFAULT_SECTION_COUNT = 30
+        const val MAX_SECTION_COUNT = 100
+        const val DEFAULT_SECTION_ORDER = "latest,calendar,random,ongoing,popular,best,upcoming"
+        private val defaultSectionKeys = DEFAULT_SECTION_ORDER.split(",")
+        private val validSectionKeys = listOf(
+            "latest",
+            "calendar",
+            "ongoing",
+            "popular",
+            "best",
+            "upcoming",
+            "random"
+        )
+
+        private val siteSchemeRegex = Regex("""(?i)^https?://""")
+        private val validSiteHostRegex = Regex(
+            pattern = """^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$""",
+            option = RegexOption.IGNORE_CASE
+        )
+
+        private fun normalizeSiteUrl(value: String?): String? {
+            val rawValue = value?.trim().orEmpty()
+            if (rawValue.isBlank()) return null
+
+            val withoutScheme = rawValue.replaceFirst(siteSchemeRegex, "")
+            val normalizedHost = withoutScheme.trimEnd('/')
+
+            if (normalizedHost.isBlank()) return null
+            if (normalizedHost.contains("/") || normalizedHost.contains("?") || normalizedHost.contains("#")) {
+                return null
+            }
+            if (!validSiteHostRegex.matches(normalizedHost)) {
+                return null
+            }
+
+            return "https://${normalizedHost.lowercase(Locale.ROOT)}/"
+        }
+
+        fun isValidSiteUrl(value: String?): Boolean {
+            return normalizeSiteUrl(value) != null
+        }
+
+        fun getValidatedSiteUrl(value: String?): String {
+            return normalizeSiteUrl(value) ?: DEFAULT_SITE_URL
+        }
+
+        fun getConfiguredSiteUrl(sharedPref: SharedPreferences?): String {
+            return getValidatedSiteUrl(sharedPref?.getString(PREF_SITE_URL, null))
+        }
+
+        fun getConfiguredBaseUrl(sharedPref: SharedPreferences?): String {
+            return getConfiguredSiteUrl(sharedPref).removeSuffix("/")
+        }
+
+        fun getValidatedSectionOrder(value: String?): String {
+            val normalizedSections = value
+                ?.split(",")
+                ?.map { it.trim().lowercase(Locale.ROOT) }
+                ?.filter { it in validSectionKeys }
+                ?.distinct()
+                .orEmpty()
+
+            return if (normalizedSections.isEmpty()) {
+                DEFAULT_SECTION_ORDER
+            } else {
+                (normalizedSections + defaultSectionKeys.filterNot { it in normalizedSections })
+                    .joinToString(",")
+            }
+        }
+
+        fun getConfiguredSectionOrder(sharedPref: SharedPreferences?): String {
+            return getValidatedSectionOrder(sharedPref?.getString(PREF_SECTION_ORDER, null))
+        }
+
+        internal var activePlugin: AnimeUnityPlugin? = null
+        internal var activeSharedPref: SharedPreferences? = null
     }
 
     private var sharedPref: SharedPreferences? = null
 
     override fun load(context: Context) {
         sharedPref = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        activePlugin = this
+        activeSharedPref = sharedPref
 
         registerMainAPI(AnimeUnity(sharedPref))
 
         openSettings = { ctx ->
             val activity = ctx as AppCompatActivity
-            AnimeUnitySettings(this, sharedPref).show(activity.supportFragmentManager, "AnimeUnitySettings")
+            activePlugin = this
+            activeSharedPref = sharedPref
+            AnimeUnitySettings().show(activity.supportFragmentManager, "AnimeUnitySettings")
         }
     }
 }

--- a/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnitySettings.kt
+++ b/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnitySettings.kt
@@ -1,26 +1,41 @@
 package it.dogior.hadEnough
 
 import android.annotation.SuppressLint
+import android.content.Intent
 import android.content.SharedPreferences
 import android.graphics.drawable.Drawable
 import android.os.Bundle
+import android.text.Editable
+import android.text.InputFilter
+import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.EditText
 import android.widget.ImageButton
+import android.widget.LinearLayout
 import android.widget.Switch
 import android.widget.TextView
-import androidx.core.content.res.ResourcesCompat
+import androidx.appcompat.app.AlertDialog
 import androidx.core.content.edit
+import androidx.core.content.res.ResourcesCompat
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.lagradost.cloudstream3.CommonActivity.showToast
 
-class AnimeUnitySettings(
-    private val plugin: AnimeUnityPlugin,
-    private val sharedPref: SharedPreferences?,
-) : BottomSheetDialogFragment() {
+abstract class AnimeUnityBaseSettingsFragment : BottomSheetDialogFragment() {
 
-    private fun View.makeTvCompatible() {
+    protected val plugin: AnimeUnityPlugin
+        get() = AnimeUnityPlugin.activePlugin
+            ?: error("AnimeUnity plugin not available")
+
+    protected val sharedPref: SharedPreferences?
+        get() = AnimeUnityPlugin.activeSharedPref
+
+    protected abstract val layoutName: String
+
+    protected fun View.makeTvCompatible() {
         this.setPadding(
             this.paddingLeft + 10,
             this.paddingTop + 10,
@@ -30,36 +45,293 @@ class AnimeUnitySettings(
         this.background = getDrawable("outline")
     }
 
+    protected fun View.applyOutlineBackground() {
+        this.background = getDrawable("outline")
+    }
+
     @SuppressLint("DiscouragedApi")
-    @Suppress("SameParameterValue")
-    private fun getDrawable(name: String): Drawable? {
+    protected fun getDrawable(name: String): Drawable? {
         val id = plugin.resources?.getIdentifier(name, "drawable", BuildConfig.LIBRARY_PACKAGE_NAME)
         return id?.let { ResourcesCompat.getDrawable(plugin.resources ?: return null, it, null) }
     }
 
     @SuppressLint("DiscouragedApi")
-    @Suppress("SameParameterValue")
-    private fun getString(name: String): String? {
+    protected fun getString(name: String): String? {
         val id = plugin.resources?.getIdentifier(name, "string", BuildConfig.LIBRARY_PACKAGE_NAME)
         return id?.let { plugin.resources?.getString(it) }
     }
 
     @SuppressLint("DiscouragedApi")
-    private fun <T : View> View.findViewByName(name: String): T? {
+    protected fun <T : View> View.findViewByName(name: String): T? {
         val id = plugin.resources?.getIdentifier(name, "id", BuildConfig.LIBRARY_PACKAGE_NAME)
         return findViewById(id ?: return null)
+    }
+
+    protected fun setupSaveButton(view: View, onClick: () -> Unit) {
+        val saveBtn: ImageButton? = view.findViewByName("save_btn")
+        saveBtn?.makeTvCompatible()
+        saveBtn?.setImageDrawable(getDrawable("save_icon"))
+        saveBtn?.setOnClickListener { onClick() }
+    }
+
+    protected fun promptRestartAfterSave(message: String) {
+        val context = context ?: return
+
+        AlertDialog.Builder(context)
+            .setTitle(getString("settings_restart_title") ?: "Riavvia applicazione")
+            .setMessage(message)
+            .setPositiveButton(getString("restart_now") ?: "Riavvia") { _, _ ->
+                dismiss()
+                restartApp()
+            }
+            .setNegativeButton(getString("restart_later") ?: "Piu tardi", null)
+            .show()
+    }
+
+    private fun restartApp() {
+        val context = context?.applicationContext ?: return
+        val packageManager = context.packageManager
+        val intent = packageManager.getLaunchIntentForPackage(context.packageName)
+        val componentName = intent?.component
+
+        if (componentName != null) {
+            val restartIntent = Intent.makeRestartActivityTask(componentName)
+            context.startActivity(restartIntent)
+            Runtime.getRuntime().exit(0)
+        } else {
+            showToast(
+                getString("restart_unavailable")
+                    ?: "Impossibile riavviare automaticamente l'app. Chiudila e riaprila manualmente."
+            )
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        (dialog as? BottomSheetDialog)?.behavior?.apply {
+            state = BottomSheetBehavior.STATE_EXPANDED
+            skipCollapsed = true
+        }
     }
 
     @SuppressLint("DiscouragedApi")
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ): View? {
         val layoutId =
-            plugin.resources?.getIdentifier("settings", "layout", BuildConfig.LIBRARY_PACKAGE_NAME)
+            plugin.resources?.getIdentifier(layoutName, "layout", BuildConfig.LIBRARY_PACKAGE_NAME)
         return layoutId?.let {
             inflater.inflate(plugin.resources?.getLayout(it), container, false)
+        }
+    }
+}
+
+class AnimeUnitySettings : AnimeUnityBaseSettingsFragment() {
+
+    override val layoutName: String = "settings"
+
+    private fun resetAllSettings(siteUrlInput: EditText?) {
+        sharedPref?.edit {
+            clear()
+        }
+
+        siteUrlInput?.error = null
+        siteUrlInput?.setText(AnimeUnityPlugin.DEFAULT_SITE_URL)
+
+        promptRestartAfterSave(
+            getString("settings_reset_restart_message")
+                ?: "Impostazioni ripristinate. Vuoi riavviare l'applicazione ora per applicare subito i valori predefiniti?"
+        )
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        view.findViewByName<TextView>("header_tw")?.text =
+            getString("settings_menu_title")
+        view.findViewByName<TextView>("home_settings_title")?.text =
+            getString("settings_menu_home_title")
+        view.findViewByName<TextView>("home_settings_summary")?.text =
+            getString("settings_menu_home_summary")
+        view.findViewByName<TextView>("home_settings_action")?.text =
+            getString("settings_open_action")
+        view.findViewByName<TextView>("display_settings_title")?.text =
+            getString("settings_menu_display_title")
+        view.findViewByName<TextView>("display_settings_summary")?.text =
+            getString("settings_menu_display_summary")
+        view.findViewByName<TextView>("display_settings_action")?.text =
+            getString("settings_open_action")
+        view.findViewByName<TextView>("site_url_label")?.text =
+            getString("site_url_label")
+
+        val homeSettingsCard: View? = view.findViewByName("home_settings_card")
+        val displaySettingsCard: View? = view.findViewByName("display_settings_card")
+        val siteUrlContainer: View? = view.findViewByName("site_url_container")
+        val siteUrlInput: EditText? = view.findViewByName("site_url_input")
+        val resetSettingsButton: TextView? = view.findViewByName("reset_settings_btn")
+
+        listOf(homeSettingsCard, displaySettingsCard).forEach { card ->
+            card?.makeTvCompatible()
+        }
+        siteUrlContainer?.applyOutlineBackground()
+        resetSettingsButton?.makeTvCompatible()
+
+        siteUrlInput?.hint = getString("site_url_hint")
+        siteUrlInput?.setText(AnimeUnityPlugin.getConfiguredSiteUrl(sharedPref))
+        resetSettingsButton?.text = getString("settings_reset_button")
+        siteUrlInput?.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) = Unit
+
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) = Unit
+
+            override fun afterTextChanged(s: Editable?) {
+                val currentValue = s?.toString()
+                siteUrlInput.error = if (
+                    currentValue.isNullOrBlank() || AnimeUnityPlugin.isValidSiteUrl(currentValue)
+                ) {
+                    null
+                } else {
+                    getString("site_url_invalid")
+                }
+            }
+        })
+
+        setupSaveButton(view) {
+            val rawSiteUrl = siteUrlInput?.text?.toString()
+            val isValidSiteUrl = AnimeUnityPlugin.isValidSiteUrl(rawSiteUrl)
+            val validatedSiteUrl = AnimeUnityPlugin.getValidatedSiteUrl(rawSiteUrl)
+
+            sharedPref?.edit {
+                putString(AnimeUnityPlugin.PREF_SITE_URL, validatedSiteUrl)
+            }
+
+            promptRestartAfterSave(
+                if (rawSiteUrl.isNullOrBlank() || isValidSiteUrl) {
+                    getString("settings_saved_restart_message")
+                        ?: "Impostazioni salvate. Vuoi riavviare l'applicazione ora per applicare subito le modifiche?"
+                } else {
+                    getString("site_url_fallback_restart_message")
+                        ?: "Link non valido: verra usato quello predefinito. Vuoi riavviare l'applicazione ora per applicare subito le modifiche?"
+                }
+            )
+        }
+
+        resetSettingsButton?.setOnClickListener {
+            val context = context ?: return@setOnClickListener
+
+            AlertDialog.Builder(context)
+                .setTitle(getString("settings_reset_title") ?: "Ripristina impostazioni")
+                .setMessage(
+                    getString("settings_reset_message")
+                        ?: "Vuoi ripristinare tutti i valori di AnimeUnity a quelli predefiniti?"
+                )
+                .setPositiveButton(getString("settings_reset_confirm") ?: "Ripristina") { _, _ ->
+                    resetAllSettings(siteUrlInput)
+                }
+                .setNegativeButton(getString("settings_reset_cancel") ?: "Annulla", null)
+                .show()
+        }
+
+        homeSettingsCard?.setOnClickListener {
+            AnimeUnityHomeSettingsFragment().show(
+                parentFragmentManager,
+                "AnimeUnityHomeSettings"
+            )
+        }
+
+        displaySettingsCard?.setOnClickListener {
+            AnimeUnityDisplaySettingsFragment().show(
+                parentFragmentManager,
+                "AnimeUnityDisplaySettings"
+            )
+        }
+    }
+}
+
+class AnimeUnityHomeSettingsFragment : AnimeUnityBaseSettingsFragment() {
+
+    override val layoutName: String = "settings_home"
+
+    private data class SectionRow(
+        val key: String,
+        val rowId: String,
+        val labelStringName: String,
+        val switchPrefKey: String,
+        val countPrefKey: String?,
+        val defaultEnabled: Boolean = true,
+    )
+
+    private fun getCount(prefKey: String): Int {
+        return (sharedPref?.getInt(prefKey, AnimeUnityPlugin.DEFAULT_SECTION_COUNT)
+            ?: AnimeUnityPlugin.DEFAULT_SECTION_COUNT).coerceIn(1, AnimeUnityPlugin.MAX_SECTION_COUNT)
+    }
+
+    private fun parseCount(input: EditText?): Int {
+        return input?.text
+            ?.toString()
+            ?.trim()
+            ?.toIntOrNull()
+            ?.coerceIn(1, AnimeUnityPlugin.MAX_SECTION_COUNT)
+            ?: AnimeUnityPlugin.DEFAULT_SECTION_COUNT
+    }
+
+    private fun setupCountInput(input: EditText?, prefKey: String) {
+        input ?: return
+
+        input.filters = arrayOf(InputFilter.LengthFilter(3))
+        input.isEnabled = true
+        input.setText(getCount(prefKey).toString())
+        input.setSelection(input.text.length)
+
+        var isUpdating = false
+        input.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) = Unit
+
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) = Unit
+
+            override fun afterTextChanged(s: Editable?) {
+                if (isUpdating) return
+
+                val currentValue = s?.toString()?.trim().orEmpty()
+                val parsedValue = currentValue.toIntOrNull() ?: return
+                if (parsedValue <= AnimeUnityPlugin.MAX_SECTION_COUNT) return
+
+                isUpdating = true
+                input.setText(AnimeUnityPlugin.MAX_SECTION_COUNT.toString())
+                input.setSelection(input.text.length)
+                isUpdating = false
+            }
+        })
+    }
+
+    private fun moveRow(container: LinearLayout, row: View, delta: Int) {
+        val currentIndex = container.indexOfChild(row)
+        if (currentIndex == -1) return
+
+        val targetIndex = (currentIndex + delta).coerceIn(0, container.childCount - 1)
+        if (targetIndex == currentIndex) return
+
+        container.removeViewAt(currentIndex)
+        container.addView(row, targetIndex)
+        updateMoveButtons(container)
+    }
+
+    private fun updateMoveButtons(container: LinearLayout) {
+        for (index in 0 until container.childCount) {
+            val row = container.getChildAt(index)
+            val canMoveUp = index > 0
+            val canMoveDown = index < container.childCount - 1
+
+            row.findViewByName<ImageButton>("move_up_btn")?.apply {
+                isEnabled = canMoveUp
+                alpha = if (canMoveUp) 1f else 0.35f
+            }
+            row.findViewByName<ImageButton>("move_down_btn")?.apply {
+                isEnabled = canMoveDown
+                alpha = if (canMoveDown) 1f else 0.35f
+            }
         }
     }
 
@@ -67,83 +339,216 @@ class AnimeUnitySettings(
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val headerTw: TextView? = view.findViewByName("header_tw")
-        headerTw?.text = getString("header_tw")
+        view.findViewByName<TextView>("header_tw")?.text =
+            getString("settings_home_title")
+        view.findViewByName<TextView>("section_name_header")?.text =
+            getString("section_name_header")
+        view.findViewByName<TextView>("section_enabled_header")?.text =
+            getString("section_enabled_header")
+        view.findViewByName<TextView>("section_limit_header")?.text =
+            getString("section_limit_header")
+        view.findViewByName<TextView>("section_move_header")?.text =
+            getString("section_move_header")
 
-        val sectionsLabel: TextView? = view.findViewByName("sections_label")
-        sectionsLabel?.text = getString("sections_label")
+        val rowsContainer: LinearLayout = view.findViewByName("sections_rows_container") ?: return
 
-        val displayLabel: TextView? = view.findViewByName("display_label")
-        displayLabel?.text = getString("display_label")
+        val sectionRows = listOf(
+            SectionRow(
+                key = "latest",
+                rowId = "latest_row",
+                labelStringName = "latest_count_label",
+                switchPrefKey = AnimeUnityPlugin.PREF_SHOW_LATEST_EPISODES,
+                countPrefKey = AnimeUnityPlugin.PREF_LATEST_COUNT,
+            ),
+            SectionRow(
+                key = "calendar",
+                rowId = "calendar_row",
+                labelStringName = "calendar_switch_text",
+                switchPrefKey = AnimeUnityPlugin.PREF_SHOW_CALENDAR,
+                countPrefKey = AnimeUnityPlugin.PREF_CALENDAR_COUNT,
+            ),
+            SectionRow(
+                key = "ongoing",
+                rowId = "ongoing_row",
+                labelStringName = "ongoing_count_label",
+                switchPrefKey = AnimeUnityPlugin.PREF_SHOW_ONGOING,
+                countPrefKey = AnimeUnityPlugin.PREF_ONGOING_COUNT,
+            ),
+            SectionRow(
+                key = "popular",
+                rowId = "popular_row",
+                labelStringName = "popular_count_label",
+                switchPrefKey = AnimeUnityPlugin.PREF_SHOW_POPULAR,
+                countPrefKey = AnimeUnityPlugin.PREF_POPULAR_COUNT,
+            ),
+            SectionRow(
+                key = "best",
+                rowId = "best_row",
+                labelStringName = "best_count_label",
+                switchPrefKey = AnimeUnityPlugin.PREF_SHOW_BEST,
+                countPrefKey = AnimeUnityPlugin.PREF_BEST_COUNT,
+            ),
+            SectionRow(
+                key = "upcoming",
+                rowId = "upcoming_row",
+                labelStringName = "upcoming_count_label",
+                switchPrefKey = AnimeUnityPlugin.PREF_SHOW_UPCOMING,
+                countPrefKey = AnimeUnityPlugin.PREF_UPCOMING_COUNT,
+            ),
+            SectionRow(
+                key = "random",
+                rowId = "random_row",
+                labelStringName = "random_count_label",
+                switchPrefKey = AnimeUnityPlugin.PREF_SHOW_RANDOM,
+                countPrefKey = AnimeUnityPlugin.PREF_RANDOM_COUNT,
+            ),
+        )
 
-        val latestEpisodesSwitch: Switch? = view.findViewByName("latest_episodes_switch")
-        latestEpisodesSwitch?.text = getString("latest_episodes_switch_text")
-        latestEpisodesSwitch?.isChecked =
-            sharedPref?.getBoolean(AnimeUnityPlugin.PREF_SHOW_LATEST_EPISODES, true) ?: true
+        val rowViewByKey = sectionRows.associate { sectionRow ->
+            val rowView = view.findViewByName<View>(sectionRow.rowId) ?: error("Missing row ${sectionRow.rowId}")
+            sectionRow.key to rowView
+        }
 
-        val calendarSwitch: Switch? = view.findViewByName("calendar_switch")
-        calendarSwitch?.text = getString("calendar_switch_text")
-        calendarSwitch?.isChecked =
-            sharedPref?.getBoolean(AnimeUnityPlugin.PREF_SHOW_CALENDAR, true) ?: true
+        val rowKeyByViewId = rowViewByKey.mapValues { (_, rowView) -> rowView.id }
+            .entries
+            .associate { (key, viewId) -> viewId to key }
 
-        val ongoingSwitch: Switch? = view.findViewByName("ongoing_switch")
-        ongoingSwitch?.text = getString("ongoing_switch_text")
-        ongoingSwitch?.isChecked =
-            sharedPref?.getBoolean(AnimeUnityPlugin.PREF_SHOW_ONGOING, true) ?: true
+        sectionRows.forEach { sectionRow ->
+            val rowView = rowViewByKey.getValue(sectionRow.key)
+            rowView.applyOutlineBackground()
 
-        val popularSwitch: Switch? = view.findViewByName("popular_switch")
-        popularSwitch?.text = getString("popular_switch_text")
-        popularSwitch?.isChecked =
-            sharedPref?.getBoolean(AnimeUnityPlugin.PREF_SHOW_POPULAR, true) ?: true
+            rowView.findViewByName<TextView>("row_label")?.text =
+                getString(sectionRow.labelStringName)
 
-        val bestSwitch: Switch? = view.findViewByName("best_switch")
-        bestSwitch?.text = getString("best_switch_text")
-        bestSwitch?.isChecked =
-            sharedPref?.getBoolean(AnimeUnityPlugin.PREF_SHOW_BEST, true) ?: true
+            val switchView = rowView.findViewByName<Switch>("row_switch")
+            switchView?.text = ""
+            switchView?.isChecked =
+                sharedPref?.getBoolean(sectionRow.switchPrefKey, sectionRow.defaultEnabled)
+                    ?: sectionRow.defaultEnabled
 
-        val upcomingSwitch: Switch? = view.findViewByName("upcoming_switch")
-        upcomingSwitch?.text = getString("upcoming_switch_text")
-        upcomingSwitch?.isChecked =
-            sharedPref?.getBoolean(AnimeUnityPlugin.PREF_SHOW_UPCOMING, true) ?: true
+            val countInput = rowView.findViewByName<EditText>("row_count_input")
+            if (sectionRow.countPrefKey != null) {
+                setupCountInput(countInput, sectionRow.countPrefKey)
+            }
 
-        val scoreSwitch: Switch? = view.findViewByName("score_switch")
-        scoreSwitch?.text = getString("score_switch_text")
-        scoreSwitch?.isChecked =
-            sharedPref?.getBoolean(AnimeUnityPlugin.PREF_SHOW_SCORE, true) ?: true
+            rowView.findViewByName<ImageButton>("move_up_btn")?.apply {
+                contentDescription = getString("move_up_action")
+                setOnClickListener { moveRow(rowsContainer, rowView, -1) }
+            }
+            rowView.findViewByName<ImageButton>("move_down_btn")?.apply {
+                contentDescription = getString("move_down_action")
+                setOnClickListener { moveRow(rowsContainer, rowView, 1) }
+            }
+        }
 
-        val saveBtn: ImageButton? = view.findViewByName("save_btn")
-        saveBtn?.makeTvCompatible()
-        saveBtn?.setImageDrawable(getDrawable("save_icon"))
-        saveBtn?.setOnClickListener {
+        rowsContainer.removeAllViews()
+        val orderedKeys = AnimeUnityPlugin.getConfiguredSectionOrder(sharedPref).split(",")
+        orderedKeys.mapNotNull { rowViewByKey[it] }.forEach(rowsContainer::addView)
+        sectionRows.map { it.key }
+            .filter { key -> rowsContainer.indexOfChild(rowViewByKey.getValue(key)) == -1 }
+            .forEach { key -> rowsContainer.addView(rowViewByKey.getValue(key)) }
+
+        updateMoveButtons(rowsContainer)
+
+        setupSaveButton(view) {
+            val validatedSectionOrder = (0 until rowsContainer.childCount)
+                .mapNotNull { index -> rowKeyByViewId[rowsContainer.getChildAt(index).id] }
+                .joinToString(",")
+
             sharedPref?.edit {
-                putBoolean(
-                    AnimeUnityPlugin.PREF_SHOW_LATEST_EPISODES,
-                    latestEpisodesSwitch?.isChecked ?: true
+                putString(
+                    AnimeUnityPlugin.PREF_SECTION_ORDER,
+                    AnimeUnityPlugin.getValidatedSectionOrder(validatedSectionOrder)
                 )
-                putBoolean(
-                    AnimeUnityPlugin.PREF_SHOW_CALENDAR,
-                    calendarSwitch?.isChecked ?: true
-                )
-                putBoolean(
-                    AnimeUnityPlugin.PREF_SHOW_ONGOING,
-                    ongoingSwitch?.isChecked ?: true
-                )
-                putBoolean(
-                    AnimeUnityPlugin.PREF_SHOW_POPULAR,
-                    popularSwitch?.isChecked ?: true
-                )
-                putBoolean(
-                    AnimeUnityPlugin.PREF_SHOW_BEST,
-                    bestSwitch?.isChecked ?: true
-                )
-                putBoolean(
-                    AnimeUnityPlugin.PREF_SHOW_UPCOMING,
-                    upcomingSwitch?.isChecked ?: true
-                )
-                putBoolean(
-                    AnimeUnityPlugin.PREF_SHOW_SCORE,
-                    scoreSwitch?.isChecked ?: true
-                )
+
+                sectionRows.forEach { sectionRow ->
+                    val rowView = rowViewByKey.getValue(sectionRow.key)
+                    putBoolean(
+                        sectionRow.switchPrefKey,
+                        rowView.findViewByName<Switch>("row_switch")?.isChecked ?: sectionRow.defaultEnabled
+                    )
+
+                    sectionRow.countPrefKey?.let { prefKey ->
+                        putInt(
+                            prefKey,
+                            parseCount(rowView.findViewByName("row_count_input"))
+                        )
+                    }
+                }
+            }
+
+            showToast(
+                getString("settings_saved")
+                    ?: "Impostazioni salvate. Riavvia l'applicazione per applicarle"
+            )
+            dismiss()
+        }
+    }
+}
+
+class AnimeUnityDisplaySettingsFragment : AnimeUnityBaseSettingsFragment() {
+
+    override val layoutName: String = "settings_display"
+
+    private data class SwitchSetting(
+        val prefKey: String,
+        val rowId: String,
+        val labelId: String,
+        val viewId: String,
+        val labelTextName: String,
+        val defaultValue: Boolean = true,
+    )
+
+    @SuppressLint("UseSwitchCompatOrMaterialCode")
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        view.findViewByName<TextView>("header_tw")?.text =
+            getString("settings_display_title")
+
+        val switchSettings = listOf(
+            SwitchSetting(
+                AnimeUnityPlugin.PREF_SHOW_DUB_SUB,
+                "dub_sub_row",
+                "dub_sub_label",
+                "dub_sub_switch",
+                "dub_sub_switch_text"
+            ),
+            SwitchSetting(
+                AnimeUnityPlugin.PREF_SHOW_EPISODE_NUMBER,
+                "episode_number_row",
+                "episode_number_label",
+                "episode_number_switch",
+                "episode_number_switch_text"
+            ),
+            SwitchSetting(
+                AnimeUnityPlugin.PREF_SHOW_SCORE,
+                "score_row",
+                "score_label",
+                "score_switch",
+                "score_switch_text"
+            ),
+        )
+
+        switchSettings.forEach { setting ->
+            view.findViewByName<View>(setting.rowId)?.applyOutlineBackground()
+            view.findViewByName<TextView>(setting.labelId)?.text =
+                getString(setting.labelTextName)
+
+            val switchView = view.findViewByName<Switch>(setting.viewId)
+            switchView?.text = ""
+            switchView?.isChecked =
+                sharedPref?.getBoolean(setting.prefKey, setting.defaultValue) ?: setting.defaultValue
+        }
+
+        setupSaveButton(view) {
+            sharedPref?.edit {
+                switchSettings.forEach { setting ->
+                    putBoolean(
+                        setting.prefKey,
+                        view.findViewByName<Switch>(setting.viewId)?.isChecked ?: setting.defaultValue
+                    )
+                }
             }
 
             showToast(

--- a/AnimeUnity/src/main/res/drawable/outline.xml
+++ b/AnimeUnity/src/main/res/drawable/outline.xml
@@ -1,20 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_focused="true">
+    <item android:state_pressed="true">
         <shape>
-            <stroke
-                android:width="2dp"
-                android:color="#FFF" />
-            <corners
-                android:bottomLeftRadius="6dp"
-                android:bottomRightRadius="6dp"
-                android:topLeftRadius="6dp"
-                android:topRightRadius="6dp" />
+            <solid android:color="#33FFFFFF" />
+            <corners android:radius="16dp" />
         </shape>
     </item>
-    <item android:state_hovered="true">
+    <item android:state_focused="true">
         <shape>
-            <solid android:color="#99FFFFFF" />
+            <solid android:color="#22FFFFFF" />
+            <stroke android:width="2dp" android:color="#88FFFFFF" />
+            <corners android:radius="16dp" />
+        </shape>
+    </item>
+    <item>
+        <shape>
+            <solid android:color="#12FFFFFF" />
+            <corners android:radius="16dp" />
         </shape>
     </item>
 </selector>

--- a/AnimeUnity/src/main/res/drawable/save_icon.xml
+++ b/AnimeUnity/src/main/res/drawable/save_icon.xml
@@ -2,9 +2,8 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24"
-    android:tint="@android:color/white">
+    android:viewportHeight="24">
     <path
-        android:fillColor="@android:color/white"
+        android:fillColor="#FFFFFF"
         android:pathData="M21,12.4V7l-4,-4H5C3.89,3 3,3.9 3,5v14c0,1.1 0.89,2 2,2h7.4L21,12.4zM15,15c0,1.66 -1.34,3 -3,3s-3,-1.34 -3,-3s1.34,-3 3,-3S15,13.34 15,15zM6,6h9v4H6V6zM19.99,16.25l1.77,1.77L16.77,23H15v-1.77L19.99,16.25zM23.25,16.51l-0.85,0.85l-1.77,-1.77l0.85,-0.85c0.2,-0.2 0.51,-0.2 0.71,0l1.06,1.06C23.45,16 23.45,16.32 23.25,16.51z" />
 </vector>

--- a/AnimeUnity/src/main/res/layout/settings.xml
+++ b/AnimeUnity/src/main/res/layout/settings.xml
@@ -1,119 +1,152 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    tools:context=".AnimeUnitySettings">
+    android:orientation="vertical"
+    android:padding="8dp">
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="48dp">
+
+        <TextView
+            android:id="@+id/header_tw"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_centerVertical="true"
+            android:textSize="24sp"
+            android:textStyle="bold" />
+
+        <ImageButton
+            android:id="@+id/save_btn"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:background="@android:color/transparent"
+            android:contentDescription="@string/save_text" />
+    </RelativeLayout>
 
     <LinearLayout
-        android:id="@+id/settingsLayout"
+        android:id="@+id/home_settings_card"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:gravity="center_horizontal"
-        android:orientation="vertical"
-        android:padding="8dp">
+        android:layout_marginTop="12dp"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center_vertical"
+        android:minHeight="68dp"
+        android:orientation="horizontal"
+        android:padding="14dp">
 
-        <RelativeLayout
-            android:layout_width="match_parent"
-            android:layout_height="48dp">
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
 
             <TextView
-                android:id="@+id/header_tw"
-                android:layout_width="wrap_content"
+                android:id="@+id/home_settings_title"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_alignParentStart="true"
-                android:layout_centerVertical="true"
-                android:text="@string/header_tw"
-                android:textSize="24sp"
+                android:textSize="17sp"
                 android:textStyle="bold" />
 
-            <ImageButton
-                android:id="@+id/save_btn"
-                android:layout_width="48dp"
-                android:layout_height="48dp"
-                android:layout_alignParentEnd="true"
-                android:layout_centerVertical="true"
-                android:background="@android:color/transparent"
-                android:contentDescription="Salva impostazioni" />
-        </RelativeLayout>
-
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="12dp"
-            android:background="@android:color/transparent" />
+            <TextView
+                android:id="@+id/home_settings_summary"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:alpha="0.8"
+                android:textSize="13sp" />
+        </LinearLayout>
 
         <TextView
-            android:id="@+id/sections_label"
-            android:layout_width="match_parent"
+            android:id="@+id/home_settings_action"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/sections_label"
+            android:layout_marginStart="12dp"
             android:textStyle="bold" />
-
-        <Switch
-            android:id="@+id/latest_episodes_switch"
-            android:layout_width="match_parent"
-            android:layout_height="48dp"
-            android:text="@string/latest_episodes_switch_text"
-            android:textSize="16sp" />
-
-        <Switch
-            android:id="@+id/calendar_switch"
-            android:layout_width="match_parent"
-            android:layout_height="48dp"
-            android:text="@string/calendar_switch_text"
-            android:textSize="16sp" />
-
-        <Switch
-            android:id="@+id/ongoing_switch"
-            android:layout_width="match_parent"
-            android:layout_height="48dp"
-            android:text="@string/ongoing_switch_text"
-            android:textSize="16sp" />
-
-        <Switch
-            android:id="@+id/popular_switch"
-            android:layout_width="match_parent"
-            android:layout_height="48dp"
-            android:text="@string/popular_switch_text"
-            android:textSize="16sp" />
-
-        <Switch
-            android:id="@+id/best_switch"
-            android:layout_width="match_parent"
-            android:layout_height="48dp"
-            android:text="@string/best_switch_text"
-            android:textSize="16sp" />
-
-        <Switch
-            android:id="@+id/upcoming_switch"
-            android:layout_width="match_parent"
-            android:layout_height="48dp"
-            android:text="@string/upcoming_switch_text"
-            android:textSize="16sp" />
-
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="12dp"
-            android:background="@android:color/transparent" />
-
-        <TextView
-            android:id="@+id/display_label"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/display_label"
-            android:textStyle="bold" />
-
-        <Switch
-            android:id="@+id/score_switch"
-            android:layout_width="match_parent"
-            android:layout_height="48dp"
-            android:text="@string/score_switch_text"
-            android:textSize="16sp" />
-
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="16dp"
-            android:background="@android:color/transparent" />
-
     </LinearLayout>
-</ScrollView>
+
+    <LinearLayout
+        android:id="@+id/display_settings_card"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center_vertical"
+        android:minHeight="68dp"
+        android:orientation="horizontal"
+        android:padding="14dp">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/display_settings_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textSize="17sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/display_settings_summary"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:alpha="0.8"
+                android:textSize="13sp" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/display_settings_action"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/site_url_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:orientation="vertical"
+        android:padding="14dp">
+
+        <TextView
+            android:id="@+id/site_url_label"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textStyle="bold" />
+
+        <EditText
+            android:id="@+id/site_url_input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:imeOptions="actionDone"
+            android:inputType="textUri"
+            android:maxLines="1"
+            android:minHeight="44dp"
+            android:singleLine="true" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/reset_settings_btn"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center"
+        android:minHeight="52dp"
+        android:padding="14dp"
+        android:textStyle="bold" />
+</LinearLayout>

--- a/AnimeUnity/src/main/res/layout/settings_display.xml
+++ b/AnimeUnity/src/main/res/layout/settings_display.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="4dp">
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="42dp">
+
+        <TextView
+            android:id="@+id/header_tw"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_centerVertical="true"
+            android:textSize="22sp"
+            android:textStyle="bold" />
+
+        <ImageButton
+            android:id="@+id/save_btn"
+            android:layout_width="44dp"
+            android:layout_height="44dp"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:background="@android:color/transparent"
+            android:contentDescription="@string/save_text" />
+    </RelativeLayout>
+
+    <LinearLayout
+        android:id="@+id/display_rows_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:id="@+id/dub_sub_row"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="2dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingStart="4dp"
+            android:paddingTop="2dp"
+            android:paddingEnd="4dp"
+            android:paddingBottom="2dp">
+
+            <TextView
+                android:id="@+id/dub_sub_label"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:textSize="12sp"
+                android:textStyle="bold" />
+
+            <Switch
+                android:id="@+id/dub_sub_switch"
+                android:layout_width="42dp"
+                android:layout_height="wrap_content"
+                android:minHeight="0dp"
+                android:showText="false"
+                android:switchMinWidth="28dp"
+                android:text="" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/episode_number_row"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="2dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingStart="4dp"
+            android:paddingTop="2dp"
+            android:paddingEnd="4dp"
+            android:paddingBottom="2dp">
+
+            <TextView
+                android:id="@+id/episode_number_label"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:textSize="12sp"
+                android:textStyle="bold" />
+
+            <Switch
+                android:id="@+id/episode_number_switch"
+                android:layout_width="42dp"
+                android:layout_height="wrap_content"
+                android:minHeight="0dp"
+                android:showText="false"
+                android:switchMinWidth="28dp"
+                android:text="" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/score_row"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingStart="4dp"
+            android:paddingTop="2dp"
+            android:paddingEnd="4dp"
+            android:paddingBottom="2dp">
+
+            <TextView
+                android:id="@+id/score_label"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:textSize="12sp"
+                android:textStyle="bold" />
+
+            <Switch
+                android:id="@+id/score_switch"
+                android:layout_width="42dp"
+                android:layout_height="wrap_content"
+                android:minHeight="0dp"
+                android:showText="false"
+                android:switchMinWidth="28dp"
+                android:text="" />
+        </LinearLayout>
+    </LinearLayout>
+</LinearLayout>

--- a/AnimeUnity/src/main/res/layout/settings_home.xml
+++ b/AnimeUnity/src/main/res/layout/settings_home.xml
@@ -1,0 +1,500 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="4dp">
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="42dp">
+
+        <TextView
+            android:id="@+id/header_tw"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_centerVertical="true"
+            android:textSize="22sp"
+            android:textStyle="bold" />
+
+        <ImageButton
+            android:id="@+id/save_btn"
+            android:layout_width="44dp"
+            android:layout_height="44dp"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:background="@android:color/transparent"
+            android:contentDescription="@string/save_text" />
+    </RelativeLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingStart="4dp"
+        android:paddingEnd="4dp">
+
+        <TextView
+            android:id="@+id/section_name_header"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:textSize="12sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/section_enabled_header"
+            android:layout_width="50dp"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:textSize="12sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/section_limit_header"
+            android:layout_width="55dp"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:textSize="12sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/section_move_header"
+            android:layout_width="74dp"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:textSize="12sp"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/sections_rows_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:id="@+id/latest_row"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="4dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingStart="4dp"
+            android:paddingTop="4dp"
+            android:paddingEnd="4dp"
+            android:paddingBottom="4dp">
+
+            <TextView
+                android:id="@+id/row_label"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:textSize="12sp"
+                android:textStyle="bold" />
+
+            <Switch
+                android:id="@+id/row_switch"
+                android:layout_width="50dp"
+                android:layout_height="wrap_content"
+                android:minHeight="0dp"
+                android:showText="false"
+                android:switchMinWidth="28dp"
+                android:text="" />
+
+            <EditText
+                android:id="@+id/row_count_input"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:gravity="center"
+                android:imeOptions="actionDone"
+                android:inputType="number"
+                android:maxLines="1"
+                android:minHeight="28dp"
+                android:singleLine="true" />
+
+            <ImageButton
+                android:id="@+id/move_up_btn"
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:layout_marginStart="10dp"
+                android:background="@android:color/transparent"
+                android:contentDescription="@string/move_up_action"
+                android:src="@android:drawable/arrow_up_float" />
+
+            <ImageButton
+                android:id="@+id/move_down_btn"
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:layout_marginStart="4dp"
+                android:background="@android:color/transparent"
+                android:contentDescription="@string/move_down_action"
+                android:src="@android:drawable/arrow_down_float" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/calendar_row"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="4dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingStart="4dp"
+            android:paddingTop="4dp"
+            android:paddingEnd="4dp"
+            android:paddingBottom="4dp">
+
+            <TextView
+                android:id="@+id/row_label"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:textSize="12sp"
+                android:textStyle="bold" />
+
+            <Switch
+                android:id="@+id/row_switch"
+                android:layout_width="50dp"
+                android:layout_height="wrap_content"
+                android:minHeight="0dp"
+                android:showText="false"
+                android:switchMinWidth="28dp"
+                android:text="" />
+
+            <EditText
+                android:id="@+id/row_count_input"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:gravity="center"
+                android:imeOptions="actionDone"
+                android:inputType="number"
+                android:maxLines="1"
+                android:minHeight="28dp"
+                android:singleLine="true" />
+
+            <ImageButton
+                android:id="@+id/move_up_btn"
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:layout_marginStart="10dp"
+                android:background="@android:color/transparent"
+                android:contentDescription="@string/move_up_action"
+                android:src="@android:drawable/arrow_up_float" />
+
+            <ImageButton
+                android:id="@+id/move_down_btn"
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:layout_marginStart="4dp"
+                android:background="@android:color/transparent"
+                android:contentDescription="@string/move_down_action"
+                android:src="@android:drawable/arrow_down_float" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/ongoing_row"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="4dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingStart="4dp"
+            android:paddingTop="4dp"
+            android:paddingEnd="4dp"
+            android:paddingBottom="4dp">
+
+            <TextView
+                android:id="@+id/row_label"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:textSize="12sp"
+                android:textStyle="bold" />
+
+            <Switch
+                android:id="@+id/row_switch"
+                android:layout_width="50dp"
+                android:layout_height="wrap_content"
+                android:minHeight="0dp"
+                android:showText="false"
+                android:switchMinWidth="28dp"
+                android:text="" />
+
+            <EditText
+                android:id="@+id/row_count_input"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:gravity="center"
+                android:imeOptions="actionDone"
+                android:inputType="number"
+                android:maxLines="1"
+                android:minHeight="28dp"
+                android:singleLine="true" />
+
+            <ImageButton
+                android:id="@+id/move_up_btn"
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:layout_marginStart="10dp"
+                android:background="@android:color/transparent"
+                android:contentDescription="@string/move_up_action"
+                android:src="@android:drawable/arrow_up_float" />
+
+            <ImageButton
+                android:id="@+id/move_down_btn"
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:layout_marginStart="4dp"
+                android:background="@android:color/transparent"
+                android:contentDescription="@string/move_down_action"
+                android:src="@android:drawable/arrow_down_float" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/popular_row"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="4dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingStart="4dp"
+            android:paddingTop="4dp"
+            android:paddingEnd="4dp"
+            android:paddingBottom="4dp">
+
+            <TextView
+                android:id="@+id/row_label"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:textSize="12sp"
+                android:textStyle="bold" />
+
+            <Switch
+                android:id="@+id/row_switch"
+                android:layout_width="50dp"
+                android:layout_height="wrap_content"
+                android:minHeight="0dp"
+                android:showText="false"
+                android:switchMinWidth="28dp"
+                android:text="" />
+
+            <EditText
+                android:id="@+id/row_count_input"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:gravity="center"
+                android:imeOptions="actionDone"
+                android:inputType="number"
+                android:maxLines="1"
+                android:minHeight="28dp"
+                android:singleLine="true" />
+
+            <ImageButton
+                android:id="@+id/move_up_btn"
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:layout_marginStart="10dp"
+                android:background="@android:color/transparent"
+                android:contentDescription="@string/move_up_action"
+                android:src="@android:drawable/arrow_up_float" />
+
+            <ImageButton
+                android:id="@+id/move_down_btn"
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:layout_marginStart="4dp"
+                android:background="@android:color/transparent"
+                android:contentDescription="@string/move_down_action"
+                android:src="@android:drawable/arrow_down_float" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/best_row"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="4dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingStart="4dp"
+            android:paddingTop="4dp"
+            android:paddingEnd="4dp"
+            android:paddingBottom="4dp">
+
+            <TextView
+                android:id="@+id/row_label"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:textSize="12sp"
+                android:textStyle="bold" />
+
+            <Switch
+                android:id="@+id/row_switch"
+                android:layout_width="50dp"
+                android:layout_height="wrap_content"
+                android:minHeight="0dp"
+                android:showText="false"
+                android:switchMinWidth="28dp"
+                android:text="" />
+
+            <EditText
+                android:id="@+id/row_count_input"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:gravity="center"
+                android:imeOptions="actionDone"
+                android:inputType="number"
+                android:maxLines="1"
+                android:minHeight="28dp"
+                android:singleLine="true" />
+
+            <ImageButton
+                android:id="@+id/move_up_btn"
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:layout_marginStart="10dp"
+                android:background="@android:color/transparent"
+                android:contentDescription="@string/move_up_action"
+                android:src="@android:drawable/arrow_up_float" />
+
+            <ImageButton
+                android:id="@+id/move_down_btn"
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:layout_marginStart="4dp"
+                android:background="@android:color/transparent"
+                android:contentDescription="@string/move_down_action"
+                android:src="@android:drawable/arrow_down_float" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/upcoming_row"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="4dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingStart="4dp"
+            android:paddingTop="4dp"
+            android:paddingEnd="4dp"
+            android:paddingBottom="4dp">
+
+            <TextView
+                android:id="@+id/row_label"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:textSize="12sp"
+                android:textStyle="bold" />
+
+            <Switch
+                android:id="@+id/row_switch"
+                android:layout_width="50dp"
+                android:layout_height="wrap_content"
+                android:minHeight="0dp"
+                android:showText="false"
+                android:switchMinWidth="28dp"
+                android:text="" />
+
+            <EditText
+                android:id="@+id/row_count_input"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:gravity="center"
+                android:imeOptions="actionDone"
+                android:inputType="number"
+                android:maxLines="1"
+                android:minHeight="28dp"
+                android:singleLine="true" />
+
+            <ImageButton
+                android:id="@+id/move_up_btn"
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:layout_marginStart="10dp"
+                android:background="@android:color/transparent"
+                android:contentDescription="@string/move_up_action"
+                android:src="@android:drawable/arrow_up_float" />
+
+            <ImageButton
+                android:id="@+id/move_down_btn"
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:layout_marginStart="4dp"
+                android:background="@android:color/transparent"
+                android:contentDescription="@string/move_down_action"
+                android:src="@android:drawable/arrow_down_float" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/random_row"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="4dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingStart="4dp"
+            android:paddingTop="4dp"
+            android:paddingEnd="4dp"
+            android:paddingBottom="4dp">
+
+            <TextView
+                android:id="@+id/row_label"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:textSize="12sp"
+                android:textStyle="bold" />
+
+            <Switch
+                android:id="@+id/row_switch"
+                android:layout_width="50dp"
+                android:layout_height="wrap_content"
+                android:minHeight="0dp"
+                android:showText="false"
+                android:switchMinWidth="28dp"
+                android:text="" />
+
+            <EditText
+                android:id="@+id/row_count_input"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:gravity="center"
+                android:imeOptions="actionDone"
+                android:inputType="number"
+                android:maxLines="1"
+                android:minHeight="28dp"
+                android:singleLine="true" />
+
+            <ImageButton
+                android:id="@+id/move_up_btn"
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:layout_marginStart="10dp"
+                android:background="@android:color/transparent"
+                android:contentDescription="@string/move_up_action"
+                android:src="@android:drawable/arrow_up_float" />
+
+            <ImageButton
+                android:id="@+id/move_down_btn"
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:layout_marginStart="4dp"
+                android:background="@android:color/transparent"
+                android:contentDescription="@string/move_down_action"
+                android:src="@android:drawable/arrow_down_float" />
+        </LinearLayout>
+    </LinearLayout>
+</LinearLayout>

--- a/AnimeUnity/src/main/res/values/strings.xml
+++ b/AnimeUnity/src/main/res/values/strings.xml
@@ -1,14 +1,56 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="header_tw">Impostazioni AnimeUnity</string>
-    <string name="sections_label">Sezioni della home</string>
-    <string name="latest_episodes_switch_text">Ultimi Episodi</string>
+    <string name="settings_menu_title">AnimeUnity</string>
+    <string name="settings_menu_home_title">Home</string>
+    <string name="settings_menu_home_summary">Personalizza Home</string>
+    <string name="settings_menu_display_title">Visualizzazione</string>
+    <string name="settings_menu_display_summary">Personalizza Scheda Anime</string>
+    <string name="settings_open_action">Apri</string>
+
+    <string name="site_url_label">Link sito</string>
+    <string name="site_url_hint">Es: animeunity.so</string>
+    <string name="site_url_invalid">Link non valido. Controlla il formato.</string>
+
+    <string name="settings_home_title">Home</string>
+    <string name="section_name_header">Sezione</string>
+    <string name="section_enabled_header">On</string>
+    <string name="section_limit_header">N.</string>
+    <string name="section_move_header">Ord.</string>
+
+    <string name="latest_episodes_switch_text">Ultimi episodi</string>
     <string name="calendar_switch_text">Calendario</string>
-    <string name="ongoing_switch_text">In Corso</string>
+    <string name="ongoing_switch_text">In corso</string>
     <string name="popular_switch_text">Popolari</string>
     <string name="best_switch_text">I migliori</string>
-    <string name="upcoming_switch_text">In Arrivo</string>
-    <string name="display_label">Visualizzazione</string>
-    <string name="score_switch_text">Mostra valutazione</string>
+    <string name="upcoming_switch_text">In arrivo</string>
+    <string name="random_switch_text">Random</string>
+
+    <string name="latest_count_label">Ultimi episodi</string>
+    <string name="ongoing_count_label">In corso</string>
+    <string name="popular_count_label">Popolari</string>
+    <string name="best_count_label">I migliori</string>
+    <string name="upcoming_count_label">In arrivo</string>
+    <string name="random_count_label">Random</string>
+
+    <string name="settings_display_title">Visualizzazione</string>
+    <string name="dub_sub_switch_text">SUB/DUB</string>
+    <string name="episode_number_switch_text">Numero episodio</string>
+    <string name="score_switch_text">Valutazione</string>
+
+    <string name="move_up_action">Sposta su</string>
+    <string name="move_down_action">Sposta giu</string>
+    <string name="save_text">Salva</string>
     <string name="settings_saved">Impostazioni salvate. Riavvia l\'applicazione per applicarle</string>
+    <string name="settings_restart_title">Riavvia applicazione</string>
+    <string name="settings_saved_restart_message">Impostazioni salvate. Vuoi riavviare l\'applicazione ora per applicare subito le modifiche?</string>
+    <string name="site_url_fallback_restart_message">Link non valido: verra usato quello predefinito. Vuoi riavviare l\'applicazione ora per applicare subito le modifiche?</string>
+    <string name="settings_reset_button">Ripristina valori predefiniti</string>
+    <string name="settings_reset_title">Ripristina impostazioni</string>
+    <string name="settings_reset_message">Vuoi ripristinare tutti i valori di AnimeUnity a quelli predefiniti?</string>
+    <string name="settings_reset_confirm">Ripristina</string>
+    <string name="settings_reset_cancel">Annulla</string>
+    <string name="settings_reset_restart_message">Impostazioni ripristinate. Vuoi riavviare l\'applicazione ora per applicare subito i valori predefiniti?</string>
+    <string name="restart_now">Riavvia</string>
+    <string name="restart_later">Piu tardi</string>
+    <string name="restart_unavailable">Impossibile riavviare automaticamente l\'app. Chiudila e riaprila manualmente.</string>
 </resources>


### PR DESCRIPTION
- Aggiunta la visualizzazione del numero dell'episodio sulla scheda anime nella Sezione Calendario
- Aggiunta una nuova sezione: Random, che mostra anime casuali

- Aggiunte nelle impostazioni di AnimeUnity:
  - Home
    - Permette di mostrare/nascondere una sezione
    - Permette di decidere quante schede anime mostrare per una specifica sezione (valori inseribili da 1 a 100 ma dipende dalla Sezione il massimo totale visualizzabile, esempio, Ultimi Episodi ha un massimo di 30)
    - Permette di cambiare l'ordinamento delle sezioni

  - Visualizzazione
    - Permette di mostrare/nascondere **SUB/DUB** sulla scheda anime
    - Permette di mostrare/nascondere il **numero dell'episodio** sulla scheda anime
    - Permette di mostrare/nascondere la **valutazione** sulla scheda anime

  - Link sito
    - Permette di cambiare il link del sito
    - Se il link non è valido, viene usato quello predefinito

  - Ripristina valori predefiniti
    - Permette di ripristinare i valori predefiniti di tutte le impostazioni di AnimeUnity