### PR TITLE
AnimeUnity: Ricerca Avanzata + fix sezione Random

### DIFF
--- a/AnimeUnity/build.gradle.kts
+++ b/AnimeUnity/build.gradle.kts
@@ -1,5 +1,5 @@
 // use an integer for version numbers
-version = 18
+version = 19
 
 
 cloudstream {

--- a/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnity.kt
+++ b/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnity.kt
@@ -56,6 +56,7 @@ class AnimeUnity(
         @Suppress("ConstPropertyName")
         const val mainUrl = "https://www.animeunity.so"
         const val ARCHIVE_BATCH_SIZE = 30
+        const val advancedSearchSectionName = "Ricerca avanzata"
         const val latestEpisodesSectionName = "Ultimi Episodi"
         const val calendarSectionName = "Calendario"
         const val randomSectionName = "Random"
@@ -81,11 +82,17 @@ class AnimeUnity(
 
     private fun buildSectionNamesList(): List<MainPageData> {
         val order = AnimeUnityPlugin.getConfiguredSectionOrder(sharedPref)
-        val sections = order.split(",")
+        val sections = buildList {
+            if (AnimeUnityPlugin.isAdvancedSearchEnabled(sharedPref)) {
+                add("advanced")
+            }
+            addAll(order.split(","))
+        }
         
         return mainPageOf(
             *sections.mapNotNull { section ->
                 when (section) {
+                    "advanced" -> "$mainUrl/archivio/" to advancedSearchSectionName
                     "latest" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_LATEST_EPISODES)) "$mainUrl/" to latestEpisodesSectionName else null
                     "calendar" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_CALENDAR)) "$mainUrl/calendario" to calendarSectionName else null
                     "ongoing" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_ONGOING)) "$mainUrl/archivio/" to ongoingSectionName else null
@@ -104,18 +111,27 @@ class AnimeUnity(
     }
 
     private fun getSectionCount(sectionName: String): Int {
-        val key = when (sectionName) {
-            latestEpisodesSectionName -> AnimeUnityPlugin.PREF_LATEST_COUNT
-            calendarSectionName -> AnimeUnityPlugin.PREF_CALENDAR_COUNT
-            ongoingSectionName -> AnimeUnityPlugin.PREF_ONGOING_COUNT
-            popularSectionName -> AnimeUnityPlugin.PREF_POPULAR_COUNT
-            bestSectionName -> AnimeUnityPlugin.PREF_BEST_COUNT
-            upcomingSectionName -> AnimeUnityPlugin.PREF_UPCOMING_COUNT
-            randomSectionName -> AnimeUnityPlugin.PREF_RANDOM_COUNT
+        val (key, defaultCount) = when (sectionName) {
+            advancedSearchSectionName -> AnimeUnityPlugin.PREF_ADVANCED_SEARCH_COUNT to
+                AnimeUnityPlugin.DEFAULT_ADVANCED_SEARCH_COUNT
+            latestEpisodesSectionName -> AnimeUnityPlugin.PREF_LATEST_COUNT to
+                AnimeUnityPlugin.DEFAULT_SECTION_COUNT
+            calendarSectionName -> AnimeUnityPlugin.PREF_CALENDAR_COUNT to
+                AnimeUnityPlugin.DEFAULT_SECTION_COUNT
+            ongoingSectionName -> AnimeUnityPlugin.PREF_ONGOING_COUNT to
+                AnimeUnityPlugin.DEFAULT_SECTION_COUNT
+            popularSectionName -> AnimeUnityPlugin.PREF_POPULAR_COUNT to
+                AnimeUnityPlugin.DEFAULT_SECTION_COUNT
+            bestSectionName -> AnimeUnityPlugin.PREF_BEST_COUNT to
+                AnimeUnityPlugin.DEFAULT_SECTION_COUNT
+            upcomingSectionName -> AnimeUnityPlugin.PREF_UPCOMING_COUNT to
+                AnimeUnityPlugin.DEFAULT_SECTION_COUNT
+            randomSectionName -> AnimeUnityPlugin.PREF_RANDOM_COUNT to
+                AnimeUnityPlugin.DEFAULT_SECTION_COUNT
             else -> return AnimeUnityPlugin.DEFAULT_SECTION_COUNT
         }
-        return (sharedPref?.getInt(key, AnimeUnityPlugin.DEFAULT_SECTION_COUNT)
-            ?: AnimeUnityPlugin.DEFAULT_SECTION_COUNT).coerceIn(1, AnimeUnityPlugin.MAX_SECTION_COUNT)
+        return (sharedPref?.getInt(key, defaultCount)
+            ?: defaultCount).coerceIn(1, AnimeUnityPlugin.MAX_SECTION_COUNT)
     }
 
     private fun shouldShowScore(): Boolean {
@@ -269,7 +285,8 @@ class AnimeUnity(
     }
 
     private suspend fun fetchRandomTitles(url: String, sectionCount: Int): Pair<List<Anime>, Int> {
-        val initialResponse = fetchArchiveBatch(url, RequestData(offset = 0))
+        val requestData = RequestData(dubbed = 0)
+        val initialResponse = fetchArchiveBatch(url, requestData.copy(offset = 0))
         val total = initialResponse.total
         val collectedTitles = linkedMapOf<Int, Anime>()
         val requestedOffsets = mutableSetOf<Int>()
@@ -297,7 +314,7 @@ class AnimeUnity(
                 return@repeat
             }
 
-            collectBatch(fetchArchiveBatch(url, RequestData(offset = randomOffset)).titles.orEmpty())
+            collectBatch(fetchArchiveBatch(url, requestData.copy(offset = randomOffset)).titles.orEmpty())
         }
 
         if (collectedTitles.isEmpty()) {
@@ -525,6 +542,7 @@ class AnimeUnity(
     }
 
     private fun getDataPerHomeSection(section: String) = when (section) {
+        advancedSearchSectionName -> AnimeUnityPlugin.getAdvancedSearchRequestData(sharedPref)
         popularSectionName -> RequestData(orderBy = Str("Popolarità"), dubbed = 0)
         upcomingSectionName -> RequestData(status = Str("In Uscita"), dubbed = 0)
         bestSectionName -> RequestData(orderBy = Str("Valutazione"), dubbed = 0)

--- a/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnityDTOs.kt
+++ b/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnityDTOs.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONArray
 import org.json.JSONObject
 
 // Sealed class to represent either Boolean or String
@@ -30,21 +31,38 @@ data class RequestData(
     val year: BooleanOrString = BooleanOrString.AsBoolean(false),
     val orderBy: BooleanOrString = BooleanOrString.AsBoolean(false),
     val status: BooleanOrString = BooleanOrString.AsBoolean(false),
-    val genres: BooleanOrString = BooleanOrString.AsBoolean(false),
+    val genres: Any = BooleanOrString.AsBoolean(false),
     /*** Inverno, Primavera, Estate, Autunno ***/
     val season: BooleanOrString = BooleanOrString.AsBoolean(false),
     var offset: Int? = 0,
     val dubbed: Int = 1,
 ){
+    private fun serializeValue(value: Any): Any {
+        return when (value) {
+            is BooleanOrString -> value.getValue()
+            is List<*> -> JSONArray().apply {
+                value.filterIsInstance<ArchiveGenreOption>().forEach { genre ->
+                    put(
+                        JSONObject().apply {
+                            put("id", genre.id)
+                            put("name", genre.name)
+                        }
+                    )
+                }
+            }
+            else -> value
+        }
+    }
+
     private fun toJson(): JSONObject {
         val m = mapOf(
             "title" to title,
-            "type" to type.getValue(),
-            "year" to year.getValue(),
-            "order" to orderBy.getValue(),
-            "status" to status.getValue(),
-            "genres" to genres.getValue(),
-            "season" to season.getValue(),
+            "type" to serializeValue(type),
+            "year" to serializeValue(year),
+            "order" to serializeValue(orderBy),
+            "status" to serializeValue(status),
+            "genres" to serializeValue(genres),
+            "season" to serializeValue(season),
             "dubbed" to dubbed,
             "offset" to offset
         )
@@ -149,6 +167,22 @@ data class AnimeInfo(
 data class Genre(
     @JsonProperty("id") val id: Int,
     @JsonProperty("name") val name: String
+)
+
+data class ArchiveGenreOption(
+    val id: Int,
+    val name: String,
+)
+
+data class AdvancedSearchConfig(
+    val enabled: Boolean,
+    val title: String,
+    val genre: ArchiveGenreOption?,
+    val year: String?,
+    val order: String?,
+    val status: String?,
+    val type: String?,
+    val season: String?,
 )
 
 data class AnilistResponse(

--- a/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnityPlugin.kt
+++ b/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnityPlugin.kt
@@ -5,6 +5,7 @@ import android.content.SharedPreferences
 import androidx.appcompat.app.AppCompatActivity
 import com.lagradost.cloudstream3.plugins.CloudstreamPlugin
 import com.lagradost.cloudstream3.plugins.Plugin
+import java.util.Calendar
 import java.util.Locale
 
 @CloudstreamPlugin
@@ -37,11 +38,22 @@ class AnimeUnityPlugin : Plugin() {
         const val PREF_SHOW_SCORE = "showScore"
 
         const val PREF_SECTION_ORDER = "sectionOrder"
+        const val PREF_ENABLE_ADVANCED_SEARCH = "enableAdvancedSearch"
+        const val PREF_ADVANCED_SEARCH_TITLE = "advancedSearchTitle"
+        const val PREF_ADVANCED_SEARCH_GENRE_ID = "advancedSearchGenreId"
+        const val PREF_ADVANCED_SEARCH_YEAR = "advancedSearchYear"
+        const val PREF_ADVANCED_SEARCH_ORDER = "advancedSearchOrder"
+        const val PREF_ADVANCED_SEARCH_STATUS = "advancedSearchStatus"
+        const val PREF_ADVANCED_SEARCH_TYPE = "advancedSearchType"
+        const val PREF_ADVANCED_SEARCH_SEASON = "advancedSearchSeason"
+        const val PREF_ADVANCED_SEARCH_COUNT = "advancedSearchCount"
 
         const val DEFAULT_SITE_URL = "https://www.animeunity.so/"
         const val DEFAULT_SECTION_COUNT = 30
         const val MAX_SECTION_COUNT = 100
+        const val DEFAULT_ADVANCED_SEARCH_COUNT = MAX_SECTION_COUNT
         const val DEFAULT_SECTION_ORDER = "latest,calendar,random,ongoing,popular,best,upcoming"
+        private const val ARCHIVE_OLDEST_YEAR = 1966
         private val defaultSectionKeys = DEFAULT_SECTION_ORDER.split(",")
         private val validSectionKeys = listOf(
             "latest",
@@ -57,6 +69,80 @@ class AnimeUnityPlugin : Plugin() {
         private val validSiteHostRegex = Regex(
             pattern = """^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$""",
             option = RegexOption.IGNORE_CASE
+        )
+        private val advancedSearchGenreOptions = listOf(
+            ArchiveGenreOption(51, "Action"),
+            ArchiveGenreOption(21, "Adventure"),
+            ArchiveGenreOption(43, "Avant Garde"),
+            ArchiveGenreOption(59, "Boys Love"),
+            ArchiveGenreOption(37, "Comedy"),
+            ArchiveGenreOption(13, "Demons"),
+            ArchiveGenreOption(22, "Drama"),
+            ArchiveGenreOption(5, "Ecchi"),
+            ArchiveGenreOption(9, "Fantasy"),
+            ArchiveGenreOption(44, "Game"),
+            ArchiveGenreOption(58, "Girls Love"),
+            ArchiveGenreOption(52, "Gore"),
+            ArchiveGenreOption(56, "Gourmet"),
+            ArchiveGenreOption(15, "Harem"),
+            ArchiveGenreOption(4, "Hentai"),
+            ArchiveGenreOption(30, "Historical"),
+            ArchiveGenreOption(3, "Horror"),
+            ArchiveGenreOption(53, "Isekai"),
+            ArchiveGenreOption(45, "Josei"),
+            ArchiveGenreOption(14, "Kids"),
+            ArchiveGenreOption(57, "Mahou Shoujo"),
+            ArchiveGenreOption(31, "Martial Arts"),
+            ArchiveGenreOption(38, "Mecha"),
+            ArchiveGenreOption(46, "Military"),
+            ArchiveGenreOption(16, "Music"),
+            ArchiveGenreOption(24, "Mystery"),
+            ArchiveGenreOption(32, "Parody"),
+            ArchiveGenreOption(39, "Police"),
+            ArchiveGenreOption(47, "Psychological"),
+            ArchiveGenreOption(29, "Racing"),
+            ArchiveGenreOption(54, "Reincarnation"),
+            ArchiveGenreOption(17, "Romance"),
+            ArchiveGenreOption(25, "Samurai"),
+            ArchiveGenreOption(33, "School"),
+            ArchiveGenreOption(40, "Sci-fi"),
+            ArchiveGenreOption(49, "Seinen"),
+            ArchiveGenreOption(18, "Shoujo"),
+            ArchiveGenreOption(34, "Shounen"),
+            ArchiveGenreOption(50, "Slice of Life"),
+            ArchiveGenreOption(19, "Space"),
+            ArchiveGenreOption(27, "Sports"),
+            ArchiveGenreOption(35, "Super Power"),
+            ArchiveGenreOption(42, "Supernatural"),
+            ArchiveGenreOption(55, "Survival"),
+            ArchiveGenreOption(48, "Thriller"),
+            ArchiveGenreOption(20, "Vampire"),
+        )
+        private val advancedSearchOrderOptions = listOf(
+            "Lista A-Z",
+            "Lista Z-A",
+            "Popolarit\u00E0",
+            "Valutazione",
+        )
+        private val advancedSearchStatusOptions = listOf(
+            "In Corso",
+            "Terminato",
+            "In Uscita",
+            "Droppato",
+        )
+        private val advancedSearchTypeOptions = listOf(
+            "TV",
+            "TV Short",
+            "OVA",
+            "ONA",
+            "Special",
+            "Movie",
+        )
+        private val advancedSearchSeasonOptions = listOf(
+            "Inverno",
+            "Primavera",
+            "Estate",
+            "Autunno",
         )
 
         private fun normalizeSiteUrl(value: String?): String? {
@@ -111,6 +197,89 @@ class AnimeUnityPlugin : Plugin() {
 
         fun getConfiguredSectionOrder(sharedPref: SharedPreferences?): String {
             return getValidatedSectionOrder(sharedPref?.getString(PREF_SECTION_ORDER, null))
+        }
+
+        fun getAdvancedSearchGenres(): List<ArchiveGenreOption> {
+            return advancedSearchGenreOptions
+        }
+
+        fun getAdvancedSearchYearOptions(): List<String> {
+            val latestYear = Calendar.getInstance().get(Calendar.YEAR) + 1
+            return (latestYear downTo ARCHIVE_OLDEST_YEAR).map(Int::toString)
+        }
+
+        fun getAdvancedSearchOrderOptions(): List<String> {
+            return advancedSearchOrderOptions
+        }
+
+        fun getAdvancedSearchStatusOptions(): List<String> {
+            return advancedSearchStatusOptions
+        }
+
+        fun getAdvancedSearchTypeOptions(): List<String> {
+            return advancedSearchTypeOptions
+        }
+
+        fun getAdvancedSearchSeasonOptions(): List<String> {
+            return advancedSearchSeasonOptions
+        }
+
+        private fun getValidatedAdvancedOption(
+            value: String?,
+            options: List<String>,
+        ): String? {
+            val normalizedValue = value?.trim().orEmpty()
+            if (normalizedValue.isBlank()) return null
+            return options.firstOrNull { it.equals(normalizedValue, ignoreCase = true) }
+        }
+
+        fun getAdvancedSearchConfig(sharedPref: SharedPreferences?): AdvancedSearchConfig {
+            val genreId = sharedPref?.getInt(PREF_ADVANCED_SEARCH_GENRE_ID, -1) ?: -1
+
+            return AdvancedSearchConfig(
+                enabled = sharedPref?.getBoolean(PREF_ENABLE_ADVANCED_SEARCH, false) ?: false,
+                title = sharedPref?.getString(PREF_ADVANCED_SEARCH_TITLE, null)?.trim().orEmpty(),
+                genre = advancedSearchGenreOptions.firstOrNull { it.id == genreId },
+                year = getValidatedAdvancedOption(
+                    sharedPref?.getString(PREF_ADVANCED_SEARCH_YEAR, null),
+                    getAdvancedSearchYearOptions(),
+                ),
+                order = getValidatedAdvancedOption(
+                    sharedPref?.getString(PREF_ADVANCED_SEARCH_ORDER, null),
+                    advancedSearchOrderOptions,
+                ),
+                status = getValidatedAdvancedOption(
+                    sharedPref?.getString(PREF_ADVANCED_SEARCH_STATUS, null),
+                    advancedSearchStatusOptions,
+                ),
+                type = getValidatedAdvancedOption(
+                    sharedPref?.getString(PREF_ADVANCED_SEARCH_TYPE, null),
+                    advancedSearchTypeOptions,
+                ),
+                season = getValidatedAdvancedOption(
+                    sharedPref?.getString(PREF_ADVANCED_SEARCH_SEASON, null),
+                    advancedSearchSeasonOptions,
+                ),
+            )
+        }
+
+        fun isAdvancedSearchEnabled(sharedPref: SharedPreferences?): Boolean {
+            return getAdvancedSearchConfig(sharedPref).enabled
+        }
+
+        fun getAdvancedSearchRequestData(sharedPref: SharedPreferences?): RequestData {
+            val config = getAdvancedSearchConfig(sharedPref)
+
+            return RequestData(
+                title = config.title,
+                type = config.type?.let(BooleanOrString::AsString) ?: BooleanOrString.AsBoolean(false),
+                year = config.year?.let(BooleanOrString::AsString) ?: BooleanOrString.AsBoolean(false),
+                orderBy = config.order?.let(BooleanOrString::AsString) ?: BooleanOrString.AsBoolean(false),
+                status = config.status?.let(BooleanOrString::AsString) ?: BooleanOrString.AsBoolean(false),
+                genres = config.genre?.let { listOf(it) } ?: BooleanOrString.AsBoolean(false),
+                season = config.season?.let(BooleanOrString::AsString) ?: BooleanOrString.AsBoolean(false),
+                dubbed = 0,
+            )
         }
 
         internal var activePlugin: AnimeUnityPlugin? = null

--- a/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnitySettings.kt
+++ b/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnitySettings.kt
@@ -3,6 +3,7 @@ package it.dogior.hadEnough
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.content.SharedPreferences
+import android.graphics.Color
 import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.text.Editable
@@ -11,6 +12,8 @@ import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.AutoCompleteTextView
+import android.widget.ArrayAdapter
 import android.widget.EditText
 import android.widget.ImageButton
 import android.widget.LinearLayout
@@ -23,6 +26,13 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.lagradost.cloudstream3.CommonActivity.showToast
+
+private data class SpinnerItem<T>(
+    val label: String,
+    val value: T,
+) {
+    override fun toString(): String = label
+}
 
 abstract class AnimeUnityBaseSettingsFragment : BottomSheetDialogFragment() {
 
@@ -132,13 +142,44 @@ class AnimeUnitySettings : AnimeUnityBaseSettingsFragment() {
 
     override val layoutName: String = "settings"
 
-    private fun resetAllSettings(siteUrlInput: EditText?) {
+    private fun setupSiteUrlResetButton(
+        button: ImageButton?,
+        input: EditText?,
+    ) {
+        button ?: return
+        button.setImageDrawable(getDrawable("clear_icon"))
+        button.setOnClickListener {
+            input?.let { siteUrlInput ->
+                siteUrlInput.error = null
+                siteUrlInput.setText(AnimeUnityPlugin.DEFAULT_SITE_URL)
+                siteUrlInput.setSelection(siteUrlInput.text.length)
+            }
+        }
+    }
+
+    private fun updateAdvancedSearchActionState(
+        actionView: TextView?,
+        enabledColor: Int,
+        isEnabled: Boolean,
+    ) {
+        actionView?.setTextColor(if (isEnabled) enabledColor else Color.parseColor("#7A7A7A"))
+        actionView?.alpha = if (isEnabled) 1f else 0.65f
+    }
+
+    private fun resetAllSettings(
+        siteUrlInput: EditText?,
+        advancedSearchSwitch: Switch?,
+        advancedSearchAction: TextView?,
+        advancedSearchActionEnabledColor: Int,
+    ) {
         sharedPref?.edit {
             clear()
         }
 
         siteUrlInput?.error = null
         siteUrlInput?.setText(AnimeUnityPlugin.DEFAULT_SITE_URL)
+        advancedSearchSwitch?.isChecked = false
+        updateAdvancedSearchActionState(advancedSearchAction, advancedSearchActionEnabledColor, false)
 
         promptRestartAfterSave(
             getString("settings_reset_restart_message")
@@ -163,23 +204,45 @@ class AnimeUnitySettings : AnimeUnityBaseSettingsFragment() {
             getString("settings_menu_display_summary")
         view.findViewByName<TextView>("display_settings_action")?.text =
             getString("settings_open_action")
+        view.findViewByName<TextView>("advanced_search_settings_title")?.text =
+            getString("settings_menu_advanced_search_title")
+        view.findViewByName<TextView>("advanced_search_settings_summary")?.text =
+            getString("settings_menu_advanced_search_summary")
+        val advancedSearchAction: TextView? = view.findViewByName("advanced_search_settings_action")
+        advancedSearchAction?.text =
+            getString("settings_open_action")
         view.findViewByName<TextView>("site_url_label")?.text =
             getString("site_url_label")
 
         val homeSettingsCard: View? = view.findViewByName("home_settings_card")
         val displaySettingsCard: View? = view.findViewByName("display_settings_card")
+        val advancedSearchSettingsCard: View? = view.findViewByName("advanced_search_settings_card")
+        val advancedSearchSwitch: Switch? = view.findViewByName("advanced_search_settings_switch")
         val siteUrlContainer: View? = view.findViewByName("site_url_container")
         val siteUrlInput: EditText? = view.findViewByName("site_url_input")
+        val siteUrlClear: ImageButton? = view.findViewByName("site_url_clear")
         val resetSettingsButton: TextView? = view.findViewByName("reset_settings_btn")
+        val advancedSearchActionEnabledColor = advancedSearchAction?.currentTextColor ?: Color.WHITE
 
-        listOf(homeSettingsCard, displaySettingsCard).forEach { card ->
+        listOf(homeSettingsCard, displaySettingsCard, advancedSearchSettingsCard).forEach { card ->
             card?.makeTvCompatible()
         }
         siteUrlContainer?.applyOutlineBackground()
         resetSettingsButton?.makeTvCompatible()
+        resetSettingsButton?.background = getDrawable("outline_danger")
+        resetSettingsButton?.setTextColor(Color.parseColor("#FFFF7F7F"))
 
         siteUrlInput?.hint = getString("site_url_hint")
         siteUrlInput?.setText(AnimeUnityPlugin.getConfiguredSiteUrl(sharedPref))
+        setupSiteUrlResetButton(siteUrlClear, siteUrlInput)
+        advancedSearchSwitch?.text = ""
+        advancedSearchSwitch?.isChecked =
+            sharedPref?.getBoolean(AnimeUnityPlugin.PREF_ENABLE_ADVANCED_SEARCH, false) ?: false
+        updateAdvancedSearchActionState(
+            advancedSearchAction,
+            advancedSearchActionEnabledColor,
+            advancedSearchSwitch?.isChecked == true
+        )
         resetSettingsButton?.text = getString("settings_reset_button")
         siteUrlInput?.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) = Unit
@@ -197,6 +260,16 @@ class AnimeUnitySettings : AnimeUnityBaseSettingsFragment() {
                 }
             }
         })
+        advancedSearchSwitch?.setOnCheckedChangeListener { _, isChecked ->
+            sharedPref?.edit {
+                putBoolean(AnimeUnityPlugin.PREF_ENABLE_ADVANCED_SEARCH, isChecked)
+            }
+            updateAdvancedSearchActionState(
+                advancedSearchAction,
+                advancedSearchActionEnabledColor,
+                isChecked
+            )
+        }
 
         setupSaveButton(view) {
             val rawSiteUrl = siteUrlInput?.text?.toString()
@@ -228,7 +301,12 @@ class AnimeUnitySettings : AnimeUnityBaseSettingsFragment() {
                         ?: "Vuoi ripristinare tutti i valori di AnimeUnity a quelli predefiniti?"
                 )
                 .setPositiveButton(getString("settings_reset_confirm") ?: "Ripristina") { _, _ ->
-                    resetAllSettings(siteUrlInput)
+                    resetAllSettings(
+                        siteUrlInput,
+                        advancedSearchSwitch,
+                        advancedSearchAction,
+                        advancedSearchActionEnabledColor
+                    )
                 }
                 .setNegativeButton(getString("settings_reset_cancel") ?: "Annulla", null)
                 .show()
@@ -246,6 +324,15 @@ class AnimeUnitySettings : AnimeUnityBaseSettingsFragment() {
                 parentFragmentManager,
                 "AnimeUnityDisplaySettings"
             )
+        }
+
+        advancedSearchSettingsCard?.setOnClickListener {
+            if (advancedSearchSwitch?.isChecked == true) {
+                AnimeUnityAdvancedSearchSettingsFragment().show(
+                    parentFragmentManager,
+                    "AnimeUnityAdvancedSearchSettings"
+                )
+            }
         }
     }
 }
@@ -549,6 +636,351 @@ class AnimeUnityDisplaySettingsFragment : AnimeUnityBaseSettingsFragment() {
                         view.findViewByName<Switch>(setting.viewId)?.isChecked ?: setting.defaultValue
                     )
                 }
+            }
+
+            showToast(
+                getString("settings_saved")
+                    ?: "Impostazioni salvate. Riavvia l'applicazione per applicarle"
+            )
+            dismiss()
+        }
+    }
+}
+
+class AnimeUnityAdvancedSearchSettingsFragment : AnimeUnityBaseSettingsFragment() {
+
+    override val layoutName: String = "settings_advanced_search"
+
+    private fun setupSelectAllOnFocus(input: EditText?) {
+        input ?: return
+        input.setOnClickListener {
+            input.post { input.selectAll() }
+        }
+        input.setOnFocusChangeListener { _, hasFocus ->
+            if (hasFocus) {
+                input.post { input.selectAll() }
+            }
+        }
+    }
+
+    private fun setupClearButton(
+        button: ImageButton?,
+        onClear: () -> Unit,
+    ) {
+        button ?: return
+        button.setImageDrawable(getDrawable("clear_icon"))
+        button.setOnClickListener { onClear() }
+    }
+
+    private fun <T> bindSelectableInput(
+        input: AutoCompleteTextView?,
+        items: List<SpinnerItem<T?>>,
+        selectedValue: T?,
+    ) {
+        val context = context ?: return
+        input ?: return
+
+        val adapter = ArrayAdapter(context, android.R.layout.simple_dropdown_item_1line, items)
+        input.setAdapter(adapter)
+        input.threshold = 0
+
+        val selectedItem = items.firstOrNull { it.value == selectedValue } ?: items.first()
+        input.setText(selectedItem.label, false)
+        input.setOnClickListener {
+            input.post {
+                input.selectAll()
+                input.showDropDown()
+            }
+        }
+        input.setOnFocusChangeListener { _, hasFocus ->
+            if (hasFocus) {
+                input.post {
+                    input.selectAll()
+                    input.showDropDown()
+                }
+            } else {
+                normalizeSelectableInput(input, items)
+            }
+        }
+        input.setOnEditorActionListener { _, _, _ ->
+            normalizeSelectableInput(input, items)
+            false
+        }
+    }
+
+    private fun <T> normalizeSelectableInput(
+        input: AutoCompleteTextView?,
+        items: List<SpinnerItem<T?>>,
+    ) {
+        input ?: return
+
+        val typedValue = input.text?.toString()?.trim().orEmpty()
+        val selectedItem = items.firstOrNull { it.label.equals(typedValue, ignoreCase = true) }
+            ?: items.first()
+
+        if (input.text?.toString() != selectedItem.label) {
+            input.setText(selectedItem.label, false)
+        }
+        input.dismissDropDown()
+    }
+
+    private fun putOptionalString(
+        editor: SharedPreferences.Editor,
+        key: String,
+        value: String?,
+    ) {
+        if (value.isNullOrBlank()) {
+            editor.remove(key)
+        } else {
+            editor.putString(key, value)
+        }
+    }
+
+    private fun getAdvancedSearchCount(): Int {
+        return (sharedPref?.getInt(
+            AnimeUnityPlugin.PREF_ADVANCED_SEARCH_COUNT,
+            AnimeUnityPlugin.DEFAULT_ADVANCED_SEARCH_COUNT,
+        ) ?: AnimeUnityPlugin.DEFAULT_ADVANCED_SEARCH_COUNT)
+            .coerceIn(1, AnimeUnityPlugin.MAX_SECTION_COUNT)
+    }
+
+    private fun parseAdvancedSearchCount(input: EditText?): Int {
+        return input?.text
+            ?.toString()
+            ?.trim()
+            ?.toIntOrNull()
+            ?.coerceIn(1, AnimeUnityPlugin.MAX_SECTION_COUNT)
+            ?: AnimeUnityPlugin.DEFAULT_ADVANCED_SEARCH_COUNT
+    }
+
+    private fun setupAdvancedSearchCountInput(input: EditText?) {
+        input ?: return
+
+        input.filters = arrayOf(InputFilter.LengthFilter(3))
+        input.setText(getAdvancedSearchCount().toString())
+        input.setSelection(input.text.length)
+
+        var isUpdating = false
+        input.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) = Unit
+
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) = Unit
+
+            override fun afterTextChanged(s: Editable?) {
+                if (isUpdating) return
+
+                val parsedValue = s?.toString()?.trim()?.toIntOrNull() ?: return
+                if (parsedValue <= AnimeUnityPlugin.MAX_SECTION_COUNT) return
+
+                isUpdating = true
+                input.setText(AnimeUnityPlugin.MAX_SECTION_COUNT.toString())
+                input.setSelection(input.text.length)
+                isUpdating = false
+            }
+        })
+    }
+
+    private fun <T> getSelectedValue(
+        input: AutoCompleteTextView?,
+        items: List<SpinnerItem<T?>>,
+    ): T? {
+        normalizeSelectableInput(input, items)
+        val typedValue = input?.text?.toString()?.trim().orEmpty()
+        return items.firstOrNull { it.label.equals(typedValue, ignoreCase = true) }?.value
+    }
+
+    @SuppressLint("UseSwitchCompatOrMaterialCode")
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        view.findViewByName<TextView>("header_tw")?.text =
+            getString("settings_advanced_search_title")
+        view.findViewByName<TextView>("advanced_search_name_label")?.text =
+            getString("advanced_search_name_label")
+        view.findViewByName<TextView>("advanced_search_genre_label")?.text =
+            getString("advanced_search_genre_label")
+        view.findViewByName<TextView>("advanced_search_year_label")?.text =
+            getString("advanced_search_year_label")
+        view.findViewByName<TextView>("advanced_search_order_label")?.text =
+            getString("advanced_search_order_label")
+        view.findViewByName<TextView>("advanced_search_status_label")?.text =
+            getString("advanced_search_status_label")
+        view.findViewByName<TextView>("advanced_search_type_label")?.text =
+            getString("advanced_search_type_label")
+        view.findViewByName<TextView>("advanced_search_season_label")?.text =
+            getString("advanced_search_season_label")
+
+        val nameRow: View? = view.findViewByName("advanced_search_name_row")
+        val countRow: View? = view.findViewByName("advanced_search_count_row")
+        val genreRow: View? = view.findViewByName("advanced_search_genre_row")
+        val yearRow: View? = view.findViewByName("advanced_search_year_row")
+        val orderRow: View? = view.findViewByName("advanced_search_order_row")
+        val statusRow: View? = view.findViewByName("advanced_search_status_row")
+        val typeRow: View? = view.findViewByName("advanced_search_type_row")
+        val seasonRow: View? = view.findViewByName("advanced_search_season_row")
+        val nameInput: EditText? = view.findViewByName("advanced_search_name_input")
+        val countInput: EditText? = view.findViewByName("advanced_search_count_input")
+        val nameClear: ImageButton? = view.findViewByName("advanced_search_name_clear")
+        val countClear: ImageButton? = view.findViewByName("advanced_search_count_clear")
+        view.findViewByName<TextView>("advanced_search_count_label")?.text =
+            getString("advanced_search_count_label")
+        val genreInput: AutoCompleteTextView? = view.findViewByName("advanced_search_genre_spinner")
+        val yearInput: AutoCompleteTextView? = view.findViewByName("advanced_search_year_spinner")
+        val orderInput: AutoCompleteTextView? = view.findViewByName("advanced_search_order_spinner")
+        val statusInput: AutoCompleteTextView? = view.findViewByName("advanced_search_status_spinner")
+        val typeInput: AutoCompleteTextView? = view.findViewByName("advanced_search_type_spinner")
+        val seasonInput: AutoCompleteTextView? = view.findViewByName("advanced_search_season_spinner")
+        val genreClear: ImageButton? = view.findViewByName("advanced_search_genre_clear")
+        val yearClear: ImageButton? = view.findViewByName("advanced_search_year_clear")
+        val orderClear: ImageButton? = view.findViewByName("advanced_search_order_clear")
+        val statusClear: ImageButton? = view.findViewByName("advanced_search_status_clear")
+        val typeClear: ImageButton? = view.findViewByName("advanced_search_type_clear")
+        val seasonClear: ImageButton? = view.findViewByName("advanced_search_season_clear")
+
+        listOf(nameRow, countRow, genreRow, yearRow, orderRow, statusRow, typeRow, seasonRow)
+            .forEach { row -> row?.applyOutlineBackground() }
+
+        val config = AnimeUnityPlugin.getAdvancedSearchConfig(sharedPref)
+        val anyOptionLabel = getString("advanced_search_any_option") ?: "Qualsiasi"
+
+        nameInput?.hint = getString("advanced_search_name_hint")
+        nameInput?.setText(config.title)
+        countInput?.hint = getString("advanced_search_count_hint")
+        genreInput?.hint = getString("advanced_search_genre_hint")
+        yearInput?.hint = getString("advanced_search_year_hint")
+        orderInput?.hint = getString("advanced_search_order_hint")
+        statusInput?.hint = getString("advanced_search_status_hint")
+        typeInput?.hint = getString("advanced_search_type_hint")
+        seasonInput?.hint = getString("advanced_search_season_hint")
+        setupAdvancedSearchCountInput(countInput)
+        setupSelectAllOnFocus(nameInput)
+        setupSelectAllOnFocus(countInput)
+
+        val genreItems = listOf(SpinnerItem<ArchiveGenreOption?>(anyOptionLabel, null)) +
+            AnimeUnityPlugin.getAdvancedSearchGenres()
+                .map { SpinnerItem<ArchiveGenreOption?>(it.name, it) }
+        val yearItems = listOf(SpinnerItem<String?>(anyOptionLabel, null)) +
+            AnimeUnityPlugin.getAdvancedSearchYearOptions()
+                .map { SpinnerItem<String?>(it, it) }
+        val orderItems = listOf(SpinnerItem<String?>(anyOptionLabel, null)) +
+            AnimeUnityPlugin.getAdvancedSearchOrderOptions()
+                .map { SpinnerItem<String?>(it, it) }
+        val statusItems = listOf(SpinnerItem<String?>(anyOptionLabel, null)) +
+            AnimeUnityPlugin.getAdvancedSearchStatusOptions()
+                .map { SpinnerItem<String?>(it, it) }
+        val typeItems = listOf(SpinnerItem<String?>(anyOptionLabel, null)) +
+            AnimeUnityPlugin.getAdvancedSearchTypeOptions()
+                .map { SpinnerItem<String?>(it, it) }
+        val seasonItems = listOf(SpinnerItem<String?>(anyOptionLabel, null)) +
+            AnimeUnityPlugin.getAdvancedSearchSeasonOptions()
+                .map { SpinnerItem<String?>(it, it) }
+
+        bindSelectableInput(
+            genreInput,
+            genreItems,
+            config.genre,
+        )
+        bindSelectableInput(
+            yearInput,
+            yearItems,
+            config.year,
+        )
+        bindSelectableInput(
+            orderInput,
+            orderItems,
+            config.order,
+        )
+        bindSelectableInput(
+            statusInput,
+            statusItems,
+            config.status,
+        )
+        bindSelectableInput(
+            typeInput,
+            typeItems,
+            config.type,
+        )
+        bindSelectableInput(
+            seasonInput,
+            seasonItems,
+            config.season,
+        )
+
+        setupClearButton(nameClear) {
+            nameInput?.setText("")
+        }
+        setupClearButton(countClear) {
+            countInput?.let { input ->
+                input.setText(AnimeUnityPlugin.DEFAULT_ADVANCED_SEARCH_COUNT.toString())
+                input.setSelection(input.text.length)
+            }
+        }
+        setupClearButton(genreClear) {
+            genreInput?.setText(anyOptionLabel, false)
+            genreInput?.dismissDropDown()
+        }
+        setupClearButton(yearClear) {
+            yearInput?.setText(anyOptionLabel, false)
+            yearInput?.dismissDropDown()
+        }
+        setupClearButton(orderClear) {
+            orderInput?.setText(anyOptionLabel, false)
+            orderInput?.dismissDropDown()
+        }
+        setupClearButton(statusClear) {
+            statusInput?.setText(anyOptionLabel, false)
+            statusInput?.dismissDropDown()
+        }
+        setupClearButton(typeClear) {
+            typeInput?.setText(anyOptionLabel, false)
+            typeInput?.dismissDropDown()
+        }
+        setupClearButton(seasonClear) {
+            seasonInput?.setText(anyOptionLabel, false)
+            seasonInput?.dismissDropDown()
+        }
+
+        setupSaveButton(view) {
+            sharedPref?.edit {
+                putOptionalString(
+                    this,
+                    AnimeUnityPlugin.PREF_ADVANCED_SEARCH_TITLE,
+                    nameInput?.text?.toString()?.trim(),
+                )
+                putInt(
+                    AnimeUnityPlugin.PREF_ADVANCED_SEARCH_COUNT,
+                    parseAdvancedSearchCount(countInput),
+                )
+
+                getSelectedValue(genreInput, genreItems)?.let { genre ->
+                    putInt(AnimeUnityPlugin.PREF_ADVANCED_SEARCH_GENRE_ID, genre.id)
+                } ?: remove(AnimeUnityPlugin.PREF_ADVANCED_SEARCH_GENRE_ID)
+
+                putOptionalString(
+                    this,
+                    AnimeUnityPlugin.PREF_ADVANCED_SEARCH_YEAR,
+                    getSelectedValue(yearInput, yearItems),
+                )
+                putOptionalString(
+                    this,
+                    AnimeUnityPlugin.PREF_ADVANCED_SEARCH_ORDER,
+                    getSelectedValue(orderInput, orderItems),
+                )
+                putOptionalString(
+                    this,
+                    AnimeUnityPlugin.PREF_ADVANCED_SEARCH_STATUS,
+                    getSelectedValue(statusInput, statusItems),
+                )
+                putOptionalString(
+                    this,
+                    AnimeUnityPlugin.PREF_ADVANCED_SEARCH_TYPE,
+                    getSelectedValue(typeInput, typeItems),
+                )
+                putOptionalString(
+                    this,
+                    AnimeUnityPlugin.PREF_ADVANCED_SEARCH_SEASON,
+                    getSelectedValue(seasonInput, seasonItems),
+                )
             }
 
             showToast(

--- a/AnimeUnity/src/main/res/drawable/clear_icon.xml
+++ b/AnimeUnity/src/main/res/drawable/clear_icon.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M19,6.41L17.59,5,12,10.59,6.41,5,5,6.41,10.59,12,5,17.59,6.41,19,12,13.41,17.59,19,19,17.59,13.41,12z" />
+</vector>

--- a/AnimeUnity/src/main/res/drawable/outline_danger.xml
+++ b/AnimeUnity/src/main/res/drawable/outline_danger.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:state_focused="true">
+        <shape android:shape="rectangle">
+            <solid android:color="#33FF6B6B" />
+            <stroke
+                android:width="2dp"
+                android:color="#FFFF7F7F" />
+            <corners android:radius="8dp" />
+        </shape>
+    </item>
+
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="#22FF6B6B" />
+            <stroke
+                android:width="2dp"
+                android:color="#CCFF7F7F" />
+            <corners android:radius="8dp" />
+        </shape>
+    </item>
+
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="#14FF6B6B" />
+            <stroke
+                android:width="2dp"
+                android:color="#99FF7F7F" />
+            <corners android:radius="8dp" />
+        </shape>
+    </item>
+</selector>

--- a/AnimeUnity/src/main/res/layout/settings.xml
+++ b/AnimeUnity/src/main/res/layout/settings.xml
@@ -113,40 +113,106 @@
     </LinearLayout>
 
     <LinearLayout
+        android:id="@+id/advanced_search_settings_card"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center_vertical"
+        android:minHeight="68dp"
+        android:orientation="horizontal"
+        android:padding="14dp">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/advanced_search_settings_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textSize="17sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/advanced_search_settings_summary"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:alpha="0.8"
+                android:textSize="13sp" />
+        </LinearLayout>
+
+        <Switch
+            android:id="@+id/advanced_search_settings_switch"
+            android:layout_width="42dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:minHeight="0dp"
+            android:showText="false"
+            android:switchMinWidth="28dp"
+            android:text="" />
+
+        <TextView
+            android:id="@+id/advanced_search_settings_action"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <LinearLayout
         android:id="@+id/site_url_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="12dp"
-        android:orientation="vertical"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
         android:padding="14dp">
 
         <TextView
             android:id="@+id/site_url_label"
-            android:layout_width="match_parent"
+            android:layout_width="64dp"
             android:layout_height="wrap_content"
             android:textStyle="bold" />
 
         <EditText
             android:id="@+id/site_url_input"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
+            android:layout_marginStart="6dp"
+            android:layout_weight="1"
             android:imeOptions="actionDone"
             android:inputType="textUri"
             android:maxLines="1"
             android:minHeight="44dp"
             android:singleLine="true" />
+
+        <ImageButton
+            android:id="@+id/site_url_clear"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
+            android:layout_marginStart="6dp"
+            android:background="@android:color/transparent"
+            android:contentDescription="@string/site_url_reset_action"
+            android:padding="4dp"
+            android:scaleType="centerInside" />
     </LinearLayout>
 
     <TextView
         android:id="@+id/reset_settings_btn"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="12dp"
+        android:layout_gravity="center_horizontal"
         android:clickable="true"
         android:focusable="true"
         android:gravity="center"
         android:minHeight="52dp"
-        android:padding="14dp"
+        android:paddingHorizontal="18dp"
+        android:paddingVertical="14dp"
         android:textStyle="bold" />
 </LinearLayout>

--- a/AnimeUnity/src/main/res/layout/settings_advanced_search.xml
+++ b/AnimeUnity/src/main/res/layout/settings_advanced_search.xml
@@ -1,0 +1,361 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="8dp">
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="48dp">
+
+        <TextView
+            android:id="@+id/header_tw"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_centerVertical="true"
+            android:textSize="24sp"
+            android:textStyle="bold" />
+
+        <ImageButton
+            android:id="@+id/save_btn"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:background="@android:color/transparent"
+            android:contentDescription="@string/save_text" />
+    </RelativeLayout>
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fillViewport="true">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <LinearLayout
+                android:id="@+id/advanced_search_name_row"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:padding="14dp">
+
+                <TextView
+                    android:id="@+id/advanced_search_name_label"
+                    android:layout_width="92dp"
+                    android:layout_height="wrap_content"
+                    android:textStyle="bold" />
+
+                <EditText
+                    android:id="@+id/advanced_search_name_input"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="10dp"
+                    android:layout_weight="1"
+                    android:hint="@string/advanced_search_name_hint"
+                    android:imeOptions="actionDone"
+                    android:inputType="text"
+                    android:maxLines="1"
+                    android:minHeight="44dp"
+                    android:singleLine="true" />
+
+                <ImageButton
+                    android:id="@+id/advanced_search_name_clear"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:layout_marginStart="6dp"
+                    android:background="@android:color/transparent"
+                    android:contentDescription="@string/advanced_search_clear_action"
+                    android:padding="4dp"
+                    android:scaleType="centerInside" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/advanced_search_count_row"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:padding="14dp">
+
+                <TextView
+                    android:id="@+id/advanced_search_count_label"
+                    android:layout_width="92dp"
+                    android:layout_height="wrap_content"
+                    android:textStyle="bold" />
+
+                <EditText
+                    android:id="@+id/advanced_search_count_input"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="10dp"
+                    android:layout_weight="1"
+                    android:hint="@string/advanced_search_count_hint"
+                    android:imeOptions="actionDone"
+                    android:inputType="number"
+                    android:maxLines="1"
+                    android:minHeight="44dp"
+                    android:singleLine="true" />
+
+                <ImageButton
+                    android:id="@+id/advanced_search_count_clear"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:layout_marginStart="6dp"
+                    android:background="@android:color/transparent"
+                    android:contentDescription="@string/advanced_search_clear_action"
+                    android:padding="4dp"
+                    android:scaleType="centerInside" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/advanced_search_genre_row"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:padding="14dp">
+
+                <TextView
+                    android:id="@+id/advanced_search_genre_label"
+                    android:layout_width="92dp"
+                    android:layout_height="wrap_content"
+                    android:textStyle="bold" />
+
+                <AutoCompleteTextView
+                    android:id="@+id/advanced_search_genre_spinner"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="10dp"
+                    android:layout_weight="1"
+                    android:completionThreshold="0"
+                    android:hint="@string/advanced_search_genre_hint"
+                    android:imeOptions="actionDone"
+                    android:inputType="text"
+                    android:maxLines="1"
+                    android:minHeight="44dp"
+                    android:singleLine="true" />
+
+                <ImageButton
+                    android:id="@+id/advanced_search_genre_clear"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:layout_marginStart="6dp"
+                    android:background="@android:color/transparent"
+                    android:contentDescription="@string/advanced_search_clear_action"
+                    android:padding="4dp"
+                    android:scaleType="centerInside" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/advanced_search_year_row"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:padding="14dp">
+
+                <TextView
+                    android:id="@+id/advanced_search_year_label"
+                    android:layout_width="92dp"
+                    android:layout_height="wrap_content"
+                    android:textStyle="bold" />
+
+                <AutoCompleteTextView
+                    android:id="@+id/advanced_search_year_spinner"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="10dp"
+                    android:layout_weight="1"
+                    android:completionThreshold="0"
+                    android:hint="@string/advanced_search_year_hint"
+                    android:imeOptions="actionDone"
+                    android:inputType="number"
+                    android:maxLines="1"
+                    android:minHeight="44dp"
+                    android:singleLine="true" />
+
+                <ImageButton
+                    android:id="@+id/advanced_search_year_clear"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:layout_marginStart="6dp"
+                    android:background="@android:color/transparent"
+                    android:contentDescription="@string/advanced_search_clear_action"
+                    android:padding="4dp"
+                    android:scaleType="centerInside" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/advanced_search_order_row"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:padding="14dp">
+
+                <TextView
+                    android:id="@+id/advanced_search_order_label"
+                    android:layout_width="92dp"
+                    android:layout_height="wrap_content"
+                    android:textStyle="bold" />
+
+                <AutoCompleteTextView
+                    android:id="@+id/advanced_search_order_spinner"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="10dp"
+                    android:layout_weight="1"
+                    android:completionThreshold="0"
+                    android:hint="@string/advanced_search_order_hint"
+                    android:imeOptions="actionDone"
+                    android:inputType="text"
+                    android:maxLines="1"
+                    android:minHeight="44dp"
+                    android:singleLine="true" />
+
+                <ImageButton
+                    android:id="@+id/advanced_search_order_clear"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:layout_marginStart="6dp"
+                    android:background="@android:color/transparent"
+                    android:contentDescription="@string/advanced_search_clear_action"
+                    android:padding="4dp"
+                    android:scaleType="centerInside" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/advanced_search_status_row"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:padding="14dp">
+
+                <TextView
+                    android:id="@+id/advanced_search_status_label"
+                    android:layout_width="92dp"
+                    android:layout_height="wrap_content"
+                    android:textStyle="bold" />
+
+                <AutoCompleteTextView
+                    android:id="@+id/advanced_search_status_spinner"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="10dp"
+                    android:layout_weight="1"
+                    android:completionThreshold="0"
+                    android:hint="@string/advanced_search_status_hint"
+                    android:imeOptions="actionDone"
+                    android:inputType="text"
+                    android:maxLines="1"
+                    android:minHeight="44dp"
+                    android:singleLine="true" />
+
+                <ImageButton
+                    android:id="@+id/advanced_search_status_clear"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:layout_marginStart="6dp"
+                    android:background="@android:color/transparent"
+                    android:contentDescription="@string/advanced_search_clear_action"
+                    android:padding="4dp"
+                    android:scaleType="centerInside" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/advanced_search_type_row"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:padding="14dp">
+
+                <TextView
+                    android:id="@+id/advanced_search_type_label"
+                    android:layout_width="92dp"
+                    android:layout_height="wrap_content"
+                    android:textStyle="bold" />
+
+                <AutoCompleteTextView
+                    android:id="@+id/advanced_search_type_spinner"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="10dp"
+                    android:layout_weight="1"
+                    android:completionThreshold="0"
+                    android:hint="@string/advanced_search_type_hint"
+                    android:imeOptions="actionDone"
+                    android:inputType="text"
+                    android:maxLines="1"
+                    android:minHeight="44dp"
+                    android:singleLine="true" />
+
+                <ImageButton
+                    android:id="@+id/advanced_search_type_clear"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:layout_marginStart="6dp"
+                    android:background="@android:color/transparent"
+                    android:contentDescription="@string/advanced_search_clear_action"
+                    android:padding="4dp"
+                    android:scaleType="centerInside" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/advanced_search_season_row"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:layout_marginBottom="12dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:padding="14dp">
+
+                <TextView
+                    android:id="@+id/advanced_search_season_label"
+                    android:layout_width="92dp"
+                    android:layout_height="wrap_content"
+                    android:textStyle="bold" />
+
+                <AutoCompleteTextView
+                    android:id="@+id/advanced_search_season_spinner"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="10dp"
+                    android:layout_weight="1"
+                    android:completionThreshold="0"
+                    android:hint="@string/advanced_search_season_hint"
+                    android:imeOptions="actionDone"
+                    android:inputType="text"
+                    android:maxLines="1"
+                    android:minHeight="44dp"
+                    android:singleLine="true" />
+
+                <ImageButton
+                    android:id="@+id/advanced_search_season_clear"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:layout_marginStart="6dp"
+                    android:background="@android:color/transparent"
+                    android:contentDescription="@string/advanced_search_clear_action"
+                    android:padding="4dp"
+                    android:scaleType="centerInside" />
+            </LinearLayout>
+        </LinearLayout>
+    </ScrollView>
+</LinearLayout>

--- a/AnimeUnity/src/main/res/values/strings.xml
+++ b/AnimeUnity/src/main/res/values/strings.xml
@@ -5,11 +5,14 @@
     <string name="settings_menu_home_summary">Personalizza Home</string>
     <string name="settings_menu_display_title">Visualizzazione</string>
     <string name="settings_menu_display_summary">Personalizza Scheda Anime</string>
+    <string name="settings_menu_advanced_search_title">Ricerca avanzata</string>
+    <string name="settings_menu_advanced_search_summary">Ricerca Anime per criteri</string>
     <string name="settings_open_action">Apri</string>
 
-    <string name="site_url_label">Link sito</string>
+    <string name="site_url_label">Link</string>
     <string name="site_url_hint">Es: animeunity.so</string>
     <string name="site_url_invalid">Link non valido. Controlla il formato.</string>
+    <string name="site_url_reset_action">Ripristina link predefinito</string>
 
     <string name="settings_home_title">Home</string>
     <string name="section_name_header">Sezione</string>
@@ -33,9 +36,28 @@
     <string name="random_count_label">Random</string>
 
     <string name="settings_display_title">Visualizzazione</string>
+    <string name="settings_advanced_search_title">Ricerca avanzata</string>
     <string name="dub_sub_switch_text">SUB/DUB</string>
     <string name="episode_number_switch_text">Numero episodio</string>
     <string name="score_switch_text">Valutazione</string>
+    <string name="advanced_search_name_label">Nome</string>
+    <string name="advanced_search_name_hint">Nome anime</string>
+    <string name="advanced_search_count_hint">Risultati</string>
+    <string name="advanced_search_count_label">Risultati</string>
+    <string name="advanced_search_genre_label">Genere</string>
+    <string name="advanced_search_genre_hint">Genere</string>
+    <string name="advanced_search_year_label">Anno</string>
+    <string name="advanced_search_year_hint">Anno</string>
+    <string name="advanced_search_order_label">Ordina</string>
+    <string name="advanced_search_order_hint">Ordina</string>
+    <string name="advanced_search_status_label">Stato</string>
+    <string name="advanced_search_status_hint">Stato</string>
+    <string name="advanced_search_type_label">Tipo</string>
+    <string name="advanced_search_type_hint">Tipo</string>
+    <string name="advanced_search_season_label">Stagione</string>
+    <string name="advanced_search_season_hint">Stagione</string>
+    <string name="advanced_search_any_option">Qualsiasi</string>
+    <string name="advanced_search_clear_action">Cancella valore</string>
 
     <string name="move_up_action">Sposta su</string>
     <string name="move_down_action">Sposta giu</string>


### PR DESCRIPTION
## Aggiunto
- Aggiunta una nuova opzione: **Ricerca Avanzata**
- Permette di cercare Anime in base a criteri (es. genere)
- I risultati vengono mostrati nella Home in una sezione dedicata
- I criteri possono essere configurati tramite un sottomenu nelle impostazioni di AnimeUnity

## Cambiamenti
- Aggiornato lo slot Link sito
- Rivisto il pulsante Ripristina valori predefiniti

## Fix
- Risolto un problema per cui la sezione **Random** mostrava solo anime doppiati