### PR TITLE
AnimeUnity

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/src
           chmod +x gradlew
+          export BUILD_COMPLETED_AT_ROME="$(TZ=Europe/Rome date +"%d/%m/%Y %H:%M")"
           ./gradlew make makePluginsJson
           cp **/build/*.cs3 $GITHUB_WORKSPACE/builds
           cp build/plugins.json $GITHUB_WORKSPACE/builds

--- a/AnimeUnity/build.gradle.kts
+++ b/AnimeUnity/build.gradle.kts
@@ -1,5 +1,38 @@
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+fun escapeBuildConfigString(value: String): String =
+    "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+
+fun resolveBuildCommitSha(): String {
+    val githubSha = providers.environmentVariable("GITHUB_SHA").orNull?.trim()
+    if (!githubSha.isNullOrEmpty()) return githubSha
+
+    return runCatching {
+        val process = ProcessBuilder("git", "rev-parse", "HEAD")
+            .directory(projectDir)
+            .redirectErrorStream(true)
+            .start()
+        process.inputStream.bufferedReader().use { it.readText().trim() }
+    }.getOrDefault("unknown")
+}
+
+fun resolveBuildCompletedAtRome(): String {
+    val envValue = providers.environmentVariable("BUILD_COMPLETED_AT_ROME").orNull?.trim()
+    if (!envValue.isNullOrEmpty()) return envValue
+
+    return SimpleDateFormat("dd/MM/yyyy HH:mm", Locale.ITALY).apply {
+        timeZone = TimeZone.getTimeZone("Europe/Rome")
+    }.format(Date())
+}
+
+val buildCommitSha = resolveBuildCommitSha()
+val buildCompletedAtRome = resolveBuildCompletedAtRome()
+
 // use an integer for version numbers
-version = 20
+version = 21
 
 
 cloudstream {
@@ -31,6 +64,15 @@ cloudstream {
 android {
     buildFeatures {
         buildConfig = true
+    }
+
+    defaultConfig {
+        buildConfigField("String", "BUILD_COMMIT_SHA", escapeBuildConfigString(buildCommitSha))
+        buildConfigField(
+            "String",
+            "BUILD_COMPLETED_AT_ROME",
+            escapeBuildConfigString(buildCompletedAtRome)
+        )
     }
 }
 

--- a/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnity.kt
+++ b/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnity.kt
@@ -79,8 +79,103 @@ class AnimeUnity(
         val hasNextPage: Boolean,
     )
 
+    private data class MainPageSectionData(
+        val key: String,
+        val baseUrl: String,
+    )
+
+    private data class GroupedAnimeCard(
+        val anime: Anime,
+        val hasDub: Boolean,
+    )
+
+    private data class GroupedLatestEpisodeCard(
+        val anime: LatestEpisodeAnime,
+        val hasDub: Boolean,
+        val episodeNumber: String,
+    )
+
+    private data class AnimePageData(
+        val anime: Anime,
+        val relatedAnime: List<Anime>,
+        val episodes: List<Episode>,
+    )
+
+    private data class EpisodeSource(
+        val number: String,
+        val url: String,
+    )
+
+    private data class EpisodePlaybackData(
+        val preferredUrl: String,
+        val subUrl: String?,
+        val dubUrl: String?,
+    )
+
+    private data class PlayerSourceOption(
+        val label: String,
+        val url: String,
+    )
+
     override val mainPage: List<MainPageData>
         get() = buildSectionNamesList()
+
+    private fun encodeMainPageSectionData(sectionKey: String, baseUrl: String): String {
+        return "$sectionKey|$baseUrl"
+    }
+
+    private fun decodeMainPageSectionData(data: String): MainPageSectionData {
+        val separatorIndex = data.indexOf('|')
+        return if (separatorIndex == -1) {
+            MainPageSectionData(key = data, baseUrl = data)
+        } else {
+            MainPageSectionData(
+                key = data.substring(0, separatorIndex),
+                baseUrl = data.substring(separatorIndex + 1),
+            )
+        }
+    }
+
+    private fun getSectionDisplayTitle(sectionKey: String): String {
+        return when (sectionKey) {
+            "latest" -> AnimeUnityPlugin.getConfiguredSectionTitle(
+                sharedPref,
+                AnimeUnityPlugin.PREF_LATEST_TITLE,
+                latestEpisodesSectionName,
+            )
+            "calendar" -> AnimeUnityPlugin.getConfiguredSectionTitle(
+                sharedPref,
+                AnimeUnityPlugin.PREF_CALENDAR_TITLE,
+                calendarSectionName,
+            )
+            "ongoing" -> AnimeUnityPlugin.getConfiguredSectionTitle(
+                sharedPref,
+                AnimeUnityPlugin.PREF_ONGOING_TITLE,
+                ongoingSectionName,
+            )
+            "popular" -> AnimeUnityPlugin.getConfiguredSectionTitle(
+                sharedPref,
+                AnimeUnityPlugin.PREF_POPULAR_TITLE,
+                popularSectionName,
+            )
+            "best" -> AnimeUnityPlugin.getConfiguredSectionTitle(
+                sharedPref,
+                AnimeUnityPlugin.PREF_BEST_TITLE,
+                bestSectionName,
+            )
+            "upcoming" -> AnimeUnityPlugin.getConfiguredSectionTitle(
+                sharedPref,
+                AnimeUnityPlugin.PREF_UPCOMING_TITLE,
+                upcomingSectionName,
+            )
+            "random" -> AnimeUnityPlugin.getConfiguredSectionTitle(
+                sharedPref,
+                AnimeUnityPlugin.PREF_RANDOM_TITLE,
+                randomSectionName,
+            )
+            else -> advancedSearchSectionName
+        }
+    }
 
     private fun buildSectionNamesList(): List<MainPageData> {
         val order = AnimeUnityPlugin.getConfiguredSectionOrder(sharedPref)
@@ -94,14 +189,28 @@ class AnimeUnity(
         return mainPageOf(
             *sections.mapNotNull { section ->
                 when (section) {
-                    "advanced" -> "$mainUrl/archivio/" to advancedSearchSectionName
-                    "latest" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_LATEST_EPISODES)) "$mainUrl/" to latestEpisodesSectionName else null
-                    "calendar" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_CALENDAR)) "$mainUrl/calendario" to calendarSectionName else null
-                    "ongoing" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_ONGOING)) "$mainUrl/archivio/" to ongoingSectionName else null
-                    "popular" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_POPULAR)) "$mainUrl/archivio/" to popularSectionName else null
-                    "best" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_BEST)) "$mainUrl/archivio/" to bestSectionName else null
-                    "upcoming" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_UPCOMING)) "$mainUrl/archivio/" to upcomingSectionName else null
-                    "random" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_RANDOM)) "$mainUrl/archivio/" to randomSectionName else null
+                    "advanced" -> encodeMainPageSectionData("advanced", "$mainUrl/archivio/") to advancedSearchSectionName
+                    "latest" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_LATEST_EPISODES)) {
+                        encodeMainPageSectionData("latest", "$mainUrl/") to getSectionDisplayTitle("latest")
+                    } else null
+                    "calendar" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_CALENDAR)) {
+                        encodeMainPageSectionData("calendar", "$mainUrl/calendario") to getSectionDisplayTitle("calendar")
+                    } else null
+                    "ongoing" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_ONGOING)) {
+                        encodeMainPageSectionData("ongoing", "$mainUrl/archivio/") to getSectionDisplayTitle("ongoing")
+                    } else null
+                    "popular" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_POPULAR)) {
+                        encodeMainPageSectionData("popular", "$mainUrl/archivio/") to getSectionDisplayTitle("popular")
+                    } else null
+                    "best" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_BEST)) {
+                        encodeMainPageSectionData("best", "$mainUrl/archivio/") to getSectionDisplayTitle("best")
+                    } else null
+                    "upcoming" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_UPCOMING)) {
+                        encodeMainPageSectionData("upcoming", "$mainUrl/archivio/") to getSectionDisplayTitle("upcoming")
+                    } else null
+                    "random" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_RANDOM)) {
+                        encodeMainPageSectionData("random", "$mainUrl/archivio/") to getSectionDisplayTitle("random")
+                    } else null
                     else -> null
                 }
             }.toTypedArray()
@@ -112,23 +221,23 @@ class AnimeUnity(
         return sharedPref?.getBoolean(prefKey, true) ?: true
     }
 
-    private fun getSectionCount(sectionName: String): Int {
-        val (key, defaultCount) = when (sectionName) {
-            advancedSearchSectionName -> AnimeUnityPlugin.PREF_ADVANCED_SEARCH_COUNT to
+    private fun getSectionCount(sectionKey: String): Int {
+        val (key, defaultCount) = when (sectionKey) {
+            "advanced" -> AnimeUnityPlugin.PREF_ADVANCED_SEARCH_COUNT to
                 AnimeUnityPlugin.DEFAULT_ADVANCED_SEARCH_COUNT
-            latestEpisodesSectionName -> AnimeUnityPlugin.PREF_LATEST_COUNT to
+            "latest" -> AnimeUnityPlugin.PREF_LATEST_COUNT to
                 AnimeUnityPlugin.DEFAULT_SECTION_COUNT
-            calendarSectionName -> AnimeUnityPlugin.PREF_CALENDAR_COUNT to
+            "calendar" -> AnimeUnityPlugin.PREF_CALENDAR_COUNT to
                 AnimeUnityPlugin.DEFAULT_SECTION_COUNT
-            ongoingSectionName -> AnimeUnityPlugin.PREF_ONGOING_COUNT to
+            "ongoing" -> AnimeUnityPlugin.PREF_ONGOING_COUNT to
                 AnimeUnityPlugin.DEFAULT_SECTION_COUNT
-            popularSectionName -> AnimeUnityPlugin.PREF_POPULAR_COUNT to
+            "popular" -> AnimeUnityPlugin.PREF_POPULAR_COUNT to
                 AnimeUnityPlugin.DEFAULT_SECTION_COUNT
-            bestSectionName -> AnimeUnityPlugin.PREF_BEST_COUNT to
+            "best" -> AnimeUnityPlugin.PREF_BEST_COUNT to
                 AnimeUnityPlugin.DEFAULT_SECTION_COUNT
-            upcomingSectionName -> AnimeUnityPlugin.PREF_UPCOMING_COUNT to
+            "upcoming" -> AnimeUnityPlugin.PREF_UPCOMING_COUNT to
                 AnimeUnityPlugin.DEFAULT_SECTION_COUNT
-            randomSectionName -> AnimeUnityPlugin.PREF_RANDOM_COUNT to
+            "random" -> AnimeUnityPlugin.PREF_RANDOM_COUNT to
                 AnimeUnityPlugin.DEFAULT_SECTION_COUNT
             else -> return AnimeUnityPlugin.DEFAULT_SECTION_COUNT
         }
@@ -148,8 +257,124 @@ class AnimeUnity(
         return sharedPref?.getBoolean(AnimeUnityPlugin.PREF_SHOW_EPISODE_NUMBER, true) ?: true
     }
 
+    private fun shouldUseUnifiedDubSubCards(): Boolean {
+        return AnimeUnityPlugin.shouldUseUnifiedDubSubCards(sharedPref)
+    }
+
     private fun withoutDubSuffix(title: String): String {
         return title.replace(" (ITA)", "")
+    }
+
+    private fun getAnimeTitle(anime: Anime): String {
+        return anime.titleIt ?: anime.titleEng ?: anime.title!!
+    }
+
+    private fun getAnimeTitle(anime: LatestEpisodeAnime): String {
+        return anime.titleIt ?: anime.titleEng ?: anime.title!!
+    }
+
+    private fun isDubAnime(anime: Anime): Boolean {
+        return anime.dub == 1 || getAnimeTitle(anime).contains("(ITA)")
+    }
+
+    private fun isDubAnime(anime: LatestEpisodeAnime): Boolean {
+        return anime.dub == 1 || getAnimeTitle(anime).contains("(ITA)")
+    }
+
+    private fun Anime.contentKey(): String {
+        return when {
+            anilistId != null -> "anilist:$anilistId"
+            malId != null -> "mal:$malId"
+            else -> "title:${normalizeJikanTitle(withoutDubSuffix(getAnimeTitle(this)))}"
+        }
+    }
+
+    private fun LatestEpisodeAnime.contentKey(): String {
+        return when {
+            anilistId != null -> "anilist:$anilistId"
+            else -> "title:${normalizeJikanTitle(withoutDubSuffix(getAnimeTitle(this)))}"
+        }
+    }
+
+    private fun Anime.cardKey(): String {
+        return if (shouldUseUnifiedDubSubCards()) contentKey() else "anime:$id"
+    }
+
+    private fun preferAnime(primary: Anime, candidate: Anime): Anime {
+        val primaryIsDub = isDubAnime(primary)
+        val candidateIsDub = isDubAnime(candidate)
+
+        return when {
+            primaryIsDub && !candidateIsDub -> candidate
+            !primaryIsDub && candidateIsDub -> primary
+            candidate.episodesCount > primary.episodesCount -> candidate
+            else -> primary
+        }
+    }
+
+    private fun preferAnime(primary: LatestEpisodeAnime, candidate: LatestEpisodeAnime): LatestEpisodeAnime {
+        val primaryIsDub = isDubAnime(primary)
+        val candidateIsDub = isDubAnime(candidate)
+
+        return when {
+            primaryIsDub && !candidateIsDub -> candidate
+            !primaryIsDub && candidateIsDub -> primary
+            candidate.episodesCount > primary.episodesCount -> candidate
+            else -> primary
+        }
+    }
+
+    private fun groupAnimeCards(animes: List<Anime>): List<GroupedAnimeCard> {
+        if (animes.isEmpty()) return emptyList()
+        if (!shouldUseUnifiedDubSubCards()) {
+            return animes.map { anime ->
+                GroupedAnimeCard(
+                    anime = anime,
+                    hasDub = isDubAnime(anime),
+                )
+            }
+        }
+
+        return animes
+            .groupBy { it.contentKey() }
+            .values
+            .map { variants ->
+                GroupedAnimeCard(
+                    anime = variants.reduce { primary, candidate -> preferAnime(primary, candidate) },
+                    hasDub = variants.any { isDubAnime(it) },
+                )
+            }
+    }
+
+    private fun groupLatestEpisodeCards(items: List<LatestEpisodeItem>): List<GroupedLatestEpisodeCard> {
+        if (items.isEmpty()) return emptyList()
+        if (!shouldUseUnifiedDubSubCards()) {
+            return items.map { item ->
+                GroupedLatestEpisodeCard(
+                    anime = item.anime,
+                    hasDub = isDubAnime(item.anime),
+                    episodeNumber = item.number,
+                )
+            }
+        }
+
+        return items
+            .groupBy { it.anime.contentKey() }
+            .values
+            .map { variants ->
+                val latestEpisode = variants.maxWithOrNull(
+                    compareBy<LatestEpisodeItem>(
+                        { parseEpisodeSortValue(it.number) ?: Double.NEGATIVE_INFINITY },
+                        { it.number }
+                    )
+                ) ?: variants.first()
+
+                GroupedLatestEpisodeCard(
+                    anime = variants.map { it.anime }.reduce { primary, candidate -> preferAnime(primary, candidate) },
+                    hasDub = variants.any { isDubAnime(it.anime) },
+                    episodeNumber = latestEpisode.number,
+                )
+            }
     }
 
     private fun getShowStatus(status: String?): ShowStatus? {
@@ -176,18 +401,22 @@ class AnimeUnity(
         }
     }
 
+    private fun getMiniCardDubStatus(hasDub: Boolean): DubStatus {
+        return if (hasDub) DubStatus.Dubbed else DubStatus.Subbed
+    }
+
     private fun applyCardDisplayState(
         response: AnimeSearchResponse,
-        dubbed: Boolean,
+        dubStatus: DubStatus,
         poster: String?,
         score: String?,
         episodeNumber: Int? = null,
     ) {
         if (shouldShowDubSub()) {
             if (shouldShowEpisodeNumber()) {
-                response.addDubStatus(dubbed, episodeNumber)
+                response.addDubStatus(dubStatus, episodeNumber)
             } else {
-                response.addDubStatus(dubbed)
+                response.addDubStatus(dubStatus)
             }
         }
 
@@ -239,8 +468,9 @@ class AnimeUnity(
     }
 
     private suspend fun searchResponseBuilder(objectList: List<Anime>, episodeNumber: Int? = null): List<SearchResponse> {
-        return objectList.amap { anime ->
-            val title = (anime.titleIt ?: anime.titleEng ?: anime.title!!)
+        return groupAnimeCards(objectList).amap { entry ->
+            val anime = entry.anime
+            val title = getAnimeTitle(anime)
             val poster = getImage(anime.imageUrl, anime.anilistId)
 
             newAnimeSearchResponse(
@@ -254,7 +484,7 @@ class AnimeUnity(
             ).apply {
                 applyCardDisplayState(
                     response = this,
-                    dubbed = anime.dub == 1 || title.contains("(ITA)"),
+                    dubStatus = getMiniCardDubStatus(entry.hasDub),
                     poster = poster,
                     score = anime.score,
                     episodeNumber = episodeNumber
@@ -274,19 +504,20 @@ class AnimeUnity(
         page: Int,
         sectionCount: Int,
     ): ArchivePageResult {
-        val pageStartOffset = (page - 1) * sectionCount
         val collectedTitles = mutableListOf<Anime>()
-        var nextOffset = pageStartOffset
+        val uniqueContentKeys = linkedSetOf<String>()
+        var nextOffset = (page - 1) * sectionCount
         var total = 0
 
-        while (collectedTitles.size < sectionCount) {
+        while (uniqueContentKeys.size < sectionCount) {
             val responseObject = fetchArchiveBatch(url, requestData.copy(offset = nextOffset))
             total = responseObject.total
 
             val batchTitles = responseObject.titles.orEmpty()
             if (batchTitles.isEmpty()) break
 
-            collectedTitles += batchTitles.take(sectionCount - collectedTitles.size)
+            collectedTitles += batchTitles
+            batchTitles.forEach { uniqueContentKeys += it.cardKey() }
             nextOffset += batchTitles.size
 
             if (nextOffset >= total || batchTitles.size < ARCHIVE_BATCH_SIZE) {
@@ -296,7 +527,7 @@ class AnimeUnity(
 
         return ArchivePageResult(
             titles = collectedTitles,
-            hasNextPage = total > pageStartOffset + collectedTitles.size,
+            hasNextPage = nextOffset < total,
         )
     }
 
@@ -341,13 +572,13 @@ class AnimeUnity(
     }
 
     private suspend fun latestEpisodesResponseBuilder(objectList: List<LatestEpisodeItem>): List<SearchResponse> {
-        return objectList.amap { item ->
-            val anime = item.anime
-            val title = (anime.titleIt ?: anime.titleEng ?: anime.title!!)
+        return groupLatestEpisodeCards(objectList).amap { entry ->
+            val anime = entry.anime
+            val title = getAnimeTitle(anime)
             val poster = getImage(anime.imageUrl, anime.anilistId)
 
             newAnimeSearchResponse(
-                name = buildDisplayTitle(title, item.number.toIntOrNull()),
+                name = buildDisplayTitle(title, entry.episodeNumber.toIntOrNull()),
                 url = "$mainUrl/anime/${anime.id}-${anime.slug}",
                 type = when {
                     anime.type == "TV" -> TvType.Anime
@@ -357,10 +588,10 @@ class AnimeUnity(
             ).apply {
                 applyCardDisplayState(
                     response = this,
-                    dubbed = anime.dub == 1 || title.contains("(ITA)"),
+                    dubStatus = getMiniCardDubStatus(entry.hasDub),
                     poster = poster,
                     score = anime.score,
-                    episodeNumber = item.number.toIntOrNull()
+                    episodeNumber = entry.episodeNumber.toIntOrNull()
                 )
             }
         }
@@ -384,6 +615,165 @@ class AnimeUnity(
             } catch (_: Exception) {}
         }
         return anilistId?.let { getAnilistPoster(it) }
+    }
+
+    private fun getAnimeUrl(anime: Anime): String {
+        return "$mainUrl/anime/${anime.id}-${anime.slug}"
+    }
+
+    private fun getEpisodeUrl(anime: Anime, episode: Episode): String {
+        return "${getAnimeUrl(anime)}/${episode.id}"
+    }
+
+    private fun parseEpisodeSortValue(number: String?): Double? {
+        return number
+            ?.trim()
+            ?.replace(',', '.')
+            ?.toDoubleOrNull()
+    }
+
+    private fun buildEpisodeDisplayName(number: String): String {
+        return "Episodio $number"
+    }
+
+    private fun buildPlayerSourceOptions(playbackData: EpisodePlaybackData): List<PlayerSourceOption> {
+        val orderedSources = mutableListOf<PlayerSourceOption>()
+        val seenUrls = linkedSetOf<String>()
+
+        fun addSource(url: String?, label: String) {
+            val normalizedUrl = url?.takeIf(String::isNotBlank) ?: return
+            if (seenUrls.add(normalizedUrl)) {
+                orderedSources += PlayerSourceOption(label = label, url = normalizedUrl)
+            }
+        }
+
+        when (playbackData.preferredUrl) {
+            playbackData.dubUrl -> {
+                addSource(playbackData.dubUrl, "[DUB]")
+                addSource(playbackData.subUrl, "[SUB]")
+            }
+            playbackData.subUrl -> {
+                addSource(playbackData.subUrl, "[SUB]")
+                addSource(playbackData.dubUrl, "[DUB]")
+            }
+            else -> {
+                addSource(playbackData.preferredUrl, "[SOURCE]")
+                addSource(playbackData.dubUrl, "[DUB]")
+                addSource(playbackData.subUrl, "[SUB]")
+            }
+        }
+
+        return orderedSources
+    }
+
+    private fun buildEpisodeSourceMap(anime: Anime?, episodes: List<Episode>): LinkedHashMap<String, EpisodeSource> {
+        val sourceAnime = anime ?: return linkedMapOf()
+        val sourceMap = linkedMapOf<String, EpisodeSource>()
+
+        episodes.forEach { episode ->
+            val rawNumber = episode.number.trim()
+            sourceMap.putIfAbsent(
+                rawNumber,
+                EpisodeSource(
+                    number = rawNumber,
+                    url = getEpisodeUrl(sourceAnime, episode),
+                )
+            )
+        }
+
+        return sourceMap
+    }
+
+    private fun buildMergedEpisodes(
+        primaryEpisodes: LinkedHashMap<String, EpisodeSource>,
+        fallbackEpisodes: LinkedHashMap<String, EpisodeSource>,
+        subEpisodes: LinkedHashMap<String, EpisodeSource>,
+        dubEpisodes: LinkedHashMap<String, EpisodeSource>,
+        fallbackNamePrefix: String? = null,
+    ): List<com.lagradost.cloudstream3.Episode> {
+        return (primaryEpisodes.keys + fallbackEpisodes.keys)
+            .distinct()
+            .sortedWith(
+                compareBy<String>(
+                    { parseEpisodeSortValue(it) ?: Double.POSITIVE_INFINITY },
+                    { it }
+                )
+            )
+            .map { episodeNumber ->
+                val source = primaryEpisodes[episodeNumber] ?: fallbackEpisodes[episodeNumber]!!
+                val isFallbackEpisode = primaryEpisodes[episodeNumber] == null
+                val playbackData = EpisodePlaybackData(
+                    preferredUrl = source.url,
+                    subUrl = subEpisodes[episodeNumber]?.url,
+                    dubUrl = dubEpisodes[episodeNumber]?.url,
+                )
+                newEpisode(playbackData) {
+                    this.episode = source.number.toIntOrNull()
+                    if (isFallbackEpisode && fallbackNamePrefix != null) {
+                        this.name = "$fallbackNamePrefix${buildEpisodeDisplayName(source.number)}"
+                    } else if (this.episode == null) {
+                        this.name = buildEpisodeDisplayName(source.number)
+                    }
+                }
+            }
+    }
+
+    private suspend fun parseAnimePageData(animePage: org.jsoup.nodes.Document): AnimePageData {
+        val relatedAnimeJsonArray = animePage.select("layout-items").attr("items-json")
+        val relatedAnime = relatedAnimeJsonArray
+            .takeIf(String::isNotBlank)
+            ?.let { runCatching { parseJson<List<Anime>>(it) }.getOrDefault(emptyList()) }
+            ?: emptyList()
+
+        val videoPlayer = animePage.select("video-player")
+        val anime = parseJson<Anime>(videoPlayer.attr("anime"))
+        val initialEpisodes = parseJson<List<Episode>>(videoPlayer.attr("episodes"))
+        val totalEpisodes = videoPlayer.attr("episodes_count").toIntOrNull() ?: initialEpisodes.size
+
+        return AnimePageData(
+            anime = anime,
+            relatedAnime = relatedAnime,
+            episodes = getAllEpisodes(anime, initialEpisodes, totalEpisodes),
+        )
+    }
+
+    private suspend fun fetchAnimePageData(url: String): AnimePageData {
+        val animePage = app.get(url).document
+        return parseAnimePageData(animePage)
+    }
+
+    private suspend fun getAllEpisodes(
+        anime: Anime,
+        initialEpisodes: List<Episode>,
+        totalEpisodes: Int,
+    ): List<Episode> {
+        val episodes = initialEpisodes.toMutableList()
+        val isEpisodeNumberMultipleOfRange = totalEpisodes % 120 == 0
+        val range = if (isEpisodeNumberMultipleOfRange) totalEpisodes / 120 else (totalEpisodes / 120) + 1
+
+        if (totalEpisodes > 120) {
+            for (i in 2..range) {
+                val endRange = if (i == range) totalEpisodes else i * 120
+                val infoUrl = "$mainUrl/info_api/${anime.id}/1?start_range=${1 + (i - 1) * 120}&end_range=${endRange}"
+                val info = app.get(infoUrl).text
+                val animeInfo = parseJson<AnimeInfo>(info)
+                episodes.addAll(animeInfo.episodes)
+            }
+        }
+
+        return episodes
+    }
+
+    private suspend fun findAnimeVariants(currentAnime: Anime): List<Anime> {
+        val searchTitle = withoutDubSuffix(getAnimeTitle(currentAnime))
+        val responseObject = fetchArchiveBatch(
+            "$mainUrl/archivio/get-animes",
+            RequestData(title = searchTitle, dubbed = 0)
+        )
+
+        return (responseObject.titles.orEmpty() + currentAnime)
+            .filter { it.contentKey() == currentAnime.contentKey() }
+            .distinctBy(Anime::id)
     }
 
     private suspend fun getAnilistPoster(anilistId: Int): String {
@@ -540,21 +930,23 @@ class AnimeUnity(
     }
 
     override suspend fun getMainPage(page: Int, request: MainPageRequest): HomePageResponse {
-        if (request.name == latestEpisodesSectionName) {
-            return getLatestEpisodesMainPage(page)
+        val sectionData = decodeMainPageSectionData(request.data)
+
+        if (sectionData.key == "latest") {
+            return getLatestEpisodesMainPage(page, request.name)
         }
-        if (request.name.startsWith(calendarSectionName)) {
-            return getCalendarMainPage(page, request)
+        if (sectionData.key == "calendar") {
+            return getCalendarMainPage(page, request.name, sectionData.baseUrl)
         }
-        if (request.name == randomSectionName) {
-            return getRandomMainPage(page)
+        if (sectionData.key == "random") {
+            return getRandomMainPage(page, request.name, sectionData.baseUrl)
         }
 
-        val url = request.data + "get-animes"
+        val url = sectionData.baseUrl + "get-animes"
         ensureHeadersAndCookies()
 
-        val requestData = getDataPerHomeSection(request.name)
-        val sectionCount = getSectionCount(request.name)
+        val requestData = getDataPerHomeSection(sectionData.key)
+        val sectionCount = getSectionCount(sectionData.key)
         val archivePage = fetchArchiveSectionPage(url, requestData, page, sectionCount)
         return newHomePageResponse(
             HomePageList(
@@ -570,11 +962,11 @@ class AnimeUnity(
         )
     }
 
-    private suspend fun getLatestEpisodesMainPage(page: Int): HomePageResponse {
-        val sectionCount = getSectionCount(latestEpisodesSectionName)
+    private suspend fun getLatestEpisodesMainPage(page: Int, sectionTitle: String): HomePageResponse {
+        val sectionCount = getSectionCount("latest")
         if (page > 1) {
             return newHomePageResponse(
-                HomePageList(name = latestEpisodesSectionName, list = emptyList(), isHorizontalImages = false),
+                HomePageList(name = sectionTitle, list = emptyList(), isHorizontalImages = false),
                 false
             )
         }
@@ -594,7 +986,7 @@ class AnimeUnity(
 
         return newHomePageResponse(
             HomePageList(
-                name = latestEpisodesSectionName,
+                name = sectionTitle,
                 list = latestEpisodesResponseBuilder(latestEpisodes),
                 isHorizontalImages = false
             ),
@@ -602,10 +994,14 @@ class AnimeUnity(
         )
     }
 
-    private suspend fun getCalendarMainPage(page: Int, request: MainPageRequest): HomePageResponse {
+    private suspend fun getCalendarMainPage(
+        page: Int,
+        sectionTitle: String,
+        requestUrl: String,
+    ): HomePageResponse {
         val currentDay = getCurrentItalianDayName()
-        val calendarTitle = "$calendarSectionName ($currentDay)"
-        val sectionCount = getSectionCount(calendarSectionName)
+        val calendarTitle = "$sectionTitle ($currentDay)"
+        val sectionCount = getSectionCount("calendar")
 
         if (page > 1) {
             return newHomePageResponse(
@@ -614,7 +1010,7 @@ class AnimeUnity(
             )
         }
 
-        val calendarAnime = app.get(request.data).document
+        val calendarAnime = app.get(requestUrl).document
             .select("calendario-item")
             .mapNotNull { item ->
                 val animeJson = item.attr("a")
@@ -629,7 +1025,7 @@ class AnimeUnity(
                     null
                 }
             }
-            .distinctBy { it.first.id }
+            .distinctBy { it.first.contentKey() }
             .take(sectionCount)
 
         return newHomePageResponse(
@@ -658,16 +1054,20 @@ class AnimeUnity(
             ?.plus(1)
     }
 
-    private suspend fun getRandomMainPage(page: Int): HomePageResponse {
-        val url = "$mainUrl/archivio/get-animes"
+    private suspend fun getRandomMainPage(
+        page: Int,
+        sectionTitle: String,
+        requestUrl: String,
+    ): HomePageResponse {
+        val url = "${requestUrl}get-animes"
         ensureHeadersAndCookies()
 
-        val sectionCount = getSectionCount(randomSectionName)
+        val sectionCount = getSectionCount("random")
         val (titles, total) = fetchRandomTitles(url, sectionCount)
 
         return newHomePageResponse(
             HomePageList(
-                name = randomSectionName,
+                name = sectionTitle,
                 list = searchResponseBuilder(titles),
                 isHorizontalImages = false
             ),
@@ -690,11 +1090,11 @@ class AnimeUnity(
     }
 
     private fun getDataPerHomeSection(section: String) = when (section) {
-        advancedSearchSectionName -> AnimeUnityPlugin.getAdvancedSearchRequestData(sharedPref)
-        popularSectionName -> RequestData(orderBy = Str("Popolarità"), dubbed = 0)
-        upcomingSectionName -> RequestData(status = Str("In Uscita"), dubbed = 0)
-        bestSectionName -> RequestData(orderBy = Str("Valutazione"), dubbed = 0)
-        ongoingSectionName -> RequestData(orderBy = Str("Popolarità"), status = Str("In Corso"), dubbed = 0)
+        "advanced" -> AnimeUnityPlugin.getAdvancedSearchRequestData(sharedPref)
+        "popular" -> RequestData(orderBy = Str("Popolarità"), dubbed = 0)
+        "upcoming" -> RequestData(status = Str("In Uscita"), dubbed = 0)
+        "best" -> RequestData(orderBy = Str("Valutazione"), dubbed = 0)
+        "ongoing" -> RequestData(orderBy = Str("Popolarità"), status = Str("In Corso"), dubbed = 0)
         else -> RequestData()
     }
 
@@ -714,78 +1114,125 @@ class AnimeUnity(
     override suspend fun load(url: String): LoadResponse {
         ensureHeadersAndCookies(forceReset = true)
         val animePage = app.get(url).document
+        val currentPageData = parseAnimePageData(animePage)
+        val currentAnime = currentPageData.anime
+        val shouldMergeVariants = shouldUseUnifiedDubSubCards()
+        val variants = if (shouldMergeVariants) findAnimeVariants(currentAnime) else listOf(currentAnime)
 
-        val relatedAnimeJsonArray = animePage.select("layout-items").attr("items-json")
-        val relatedAnime = parseJson<List<Anime>>(relatedAnimeJsonArray)
+        val subAnime = variants.firstOrNull { !isDubAnime(it) } ?: currentAnime.takeIf { !isDubAnime(it) }
+        val dubAnime = variants.firstOrNull { isDubAnime(it) } ?: currentAnime.takeIf { isDubAnime(it) }
 
-        val videoPlayer = animePage.select("video-player")
-        val anime = parseJson<Anime>(videoPlayer.attr("anime"))
-
-        val eps = parseJson<List<Episode>>(videoPlayer.attr("episodes"))
-        val totalEps = videoPlayer.attr("episodes_count").toInt()
-        val isEpNumberMultipleOfRange = totalEps % 120 == 0
-        val range = if (isEpNumberMultipleOfRange) totalEps / 120 else (totalEps / 120) + 1
-        
-        val episodes = eps.map {
-            newEpisode("$url/${it.id}") { this.episode = it.number.toIntOrNull() }
-        }.toMutableList()
-
-        if (totalEps > 120) {
-            for (i in 2..range) {
-                val endRange = if (i == range) totalEps else i * 120
-                val infoUrl = "$mainUrl/info_api/${anime.id}/1?start_range=${1 + (i - 1) * 120}&end_range=${endRange}"
-                val info = app.get(infoUrl).text
-                val animeInfo = parseJson<AnimeInfo>(info)
-                episodes.addAll(animeInfo.episodes.map {
-                    newEpisode("$url/${it.id}") { this.episode = it.number.toIntOrNull() }
-                })
-            }
+        val subPageData = when {
+            subAnime == null -> null
+            subAnime.id == currentAnime.id -> currentPageData
+            !shouldMergeVariants -> null
+            else -> fetchAnimePageData(getAnimeUrl(subAnime))
         }
-        val title = anime.titleIt ?: anime.titleEng ?: anime.title!!
-        val relatedAnimes = relatedAnime.amap {
-            val relatedTitle = (it.titleIt ?: it.titleEng ?: it.title!!)
-            val poster = getImage(it.imageUrl, it.anilistId)
+
+        val dubPageData = when {
+            dubAnime == null -> null
+            dubAnime.id == currentAnime.id -> currentPageData
+            !shouldMergeVariants -> null
+            else -> fetchAnimePageData(getAnimeUrl(dubAnime))
+        }
+
+        val primaryAnime = subPageData?.anime ?: dubPageData?.anime ?: currentAnime
+        val title = getAnimeTitle(primaryAnime)
+        val relatedAnimes = groupAnimeCards(currentPageData.relatedAnime).amap { entry ->
+            val anime = entry.anime
+            val relatedTitle = getAnimeTitle(anime)
+            val poster = getImage(anime.imageUrl, anime.anilistId)
             newAnimeSearchResponse(
                 name = withoutDubSuffix(relatedTitle),
-                url = "$mainUrl/anime/${it.id}-${it.slug}",
-                type = if (it.type == "TV") TvType.Anime
-                else if (it.type == "Movie" || it.episodesCount == 1) TvType.AnimeMovie
+                url = "$mainUrl/anime/${anime.id}-${anime.slug}",
+                type = if (anime.type == "TV") TvType.Anime
+                else if (anime.type == "Movie" || anime.episodesCount == 1) TvType.AnimeMovie
                 else TvType.OVA
             ) {
                 if (shouldShowDubSub()) {
-                    addDubStatus(it.dub == 1 || relatedTitle.contains("(ITA)"))
+                    addDubStatus(getMiniCardDubStatus(entry.hasDub))
                 }
                 addPoster(poster)
             }
         }
-        val trailerUrl = getTrailerUrl(anime)
+
+        val subEpisodeMap = buildEpisodeSourceMap(subPageData?.anime, subPageData?.episodes.orEmpty())
+        val dubEpisodeMap = buildEpisodeSourceMap(dubPageData?.anime, dubPageData?.episodes.orEmpty())
+        val subEpisodes = if (shouldMergeVariants) {
+            buildMergedEpisodes(
+                primaryEpisodes = subEpisodeMap,
+                fallbackEpisodes = dubEpisodeMap,
+                subEpisodes = subEpisodeMap,
+                dubEpisodes = dubEpisodeMap,
+            )
+        } else {
+            buildMergedEpisodes(
+                primaryEpisodes = subEpisodeMap,
+                fallbackEpisodes = linkedMapOf(),
+                subEpisodes = subEpisodeMap,
+                dubEpisodes = linkedMapOf(),
+            )
+        }
+        val dubEpisodes = if (shouldMergeVariants) {
+            buildMergedEpisodes(
+                primaryEpisodes = dubEpisodeMap,
+                fallbackEpisodes = subEpisodeMap,
+                subEpisodes = subEpisodeMap,
+                dubEpisodes = dubEpisodeMap,
+                fallbackNamePrefix = "[SUB] - ",
+            )
+        } else {
+            buildMergedEpisodes(
+                primaryEpisodes = dubEpisodeMap,
+                fallbackEpisodes = linkedMapOf(),
+                subEpisodes = linkedMapOf(),
+                dubEpisodes = dubEpisodeMap,
+            )
+        }
+        val hasSub = subEpisodeMap.isNotEmpty()
+        val hasDub = dubEpisodeMap.isNotEmpty()
+        val trailerUrl = getTrailerUrl(primaryAnime)
 
         return newAnimeLoadResponse(
             name = title.replace(" (ITA)", ""),
-            url = url,
-            type = if (anime.type == "TV") TvType.Anime
-            else if (anime.type == "Movie" || anime.episodesCount == 1) TvType.AnimeMovie
+            url = getAnimeUrl(primaryAnime),
+            type = if (primaryAnime.type == "TV") TvType.Anime
+            else if (primaryAnime.type == "Movie" || primaryAnime.episodesCount == 1) TvType.AnimeMovie
             else TvType.OVA,
         ) {
-            this.posterUrl = getImage(anime.imageUrl, anime.anilistId)
-            anime.cover?.let { this.backgroundPosterUrl = getBanner(it) }
-            this.year = anime.date.toInt()
-            addScore(anime.score)
-            addDuration(anime.episodesLength.toString() + " minuti")
-            val dub = if (anime.dub == 1) DubStatus.Dubbed else DubStatus.Subbed
-            addEpisodes(dub, episodes)
-            addAniListId(anime.anilistId)
-            addMalId(anime.malId)
+            this.posterUrl = getImage(primaryAnime.imageUrl, primaryAnime.anilistId)
+            primaryAnime.cover?.let { this.backgroundPosterUrl = getBanner(it) }
+            this.year = primaryAnime.date.toIntOrNull()
+            addScore(primaryAnime.score)
+            addDuration(primaryAnime.episodesLength.toString() + " minuti")
+            when {
+                hasSub && hasDub -> {
+                    addEpisodes(DubStatus.Subbed, subEpisodes)
+                    addEpisodes(DubStatus.Dubbed, dubEpisodes)
+                }
+                hasDub -> {
+                    addEpisodes(DubStatus.Dubbed, dubEpisodes)
+                }
+                hasSub -> {
+                    addEpisodes(DubStatus.Subbed, subEpisodes)
+                }
+            }
+            addAniListId(primaryAnime.anilistId)
+            addMalId(primaryAnime.malId)
             if (trailerUrl != null) {
                 addTrailer(trailerUrl)
             }
-            this.showStatus = getShowStatus(anime.status)
-            this.plot = anime.plot
-            val doppiato = if (anime.dub == 1 || title.contains("(ITA)")) "\uD83C\uDDEE\uD83C\uDDF9  Italiano" else "\uD83C\uDDEF\uD83C\uDDF5  Giapponese"
-            this.tags = listOfNotNull(doppiato, getStatusTag(anime.status)) + anime.genres.map { genre ->
+            this.showStatus = getShowStatus(primaryAnime.status)
+            this.plot = primaryAnime.plot
+            val audioTag = when {
+                hasSub && hasDub -> "\uD83C\uDDEE\uD83C\uDDF9  Italiano / \uD83C\uDDEF\uD83C\uDDF5  Giapponese"
+                hasDub -> "\uD83C\uDDEE\uD83C\uDDF9  Italiano"
+                else -> "\uD83C\uDDEF\uD83C\uDDF5  Giapponese"
+            }
+            this.tags = listOfNotNull(audioTag, getStatusTag(primaryAnime.status)) + primaryAnime.genres.map { genre ->
                 genre.name.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
             }
-            this.comingSoon = anime.status == "In uscita prossimamente"
+            this.comingSoon = primaryAnime.status == "In uscita prossimamente"
             this.recommendations = relatedAnimes
         }
     }
@@ -806,14 +1253,30 @@ class AnimeUnity(
         subtitleCallback: (SubtitleFile) -> Unit,
         callback: (ExtractorLink) -> Unit,
     ): Boolean {
-        val document = app.get(data).document
-        val sourceUrl = document.select("video-player").attr("embed_url")
-        VixCloudExtractor().getUrl(
-            url = sourceUrl,
-            referer = mainUrl,
-            subtitleCallback = subtitleCallback,
-            callback = callback
-        )
+        val playbackData = runCatching { parseJson<EpisodePlaybackData>(data) }.getOrNull()
+        val playerSources = playbackData?.let(::buildPlayerSourceOptions)
+            ?.takeIf { it.isNotEmpty() }
+            ?: listOf(PlayerSourceOption(label = "[SOURCE]", url = data))
+
+        val shouldLabelSources = playerSources.size > 1
+
+        playerSources.forEach { playerSource ->
+            val document = app.get(playerSource.url).document
+            val sourceUrl = document.select("video-player").attr("embed_url")
+            if (sourceUrl.isBlank()) return@forEach
+
+            val sourceSuffix = if (shouldLabelSources) " ${playerSource.label}" else ""
+            VixCloudExtractor(
+                sourceName = "VixCloud$sourceSuffix",
+                displayName = "AnimeUnity$sourceSuffix",
+            ).getUrl(
+                url = sourceUrl,
+                referer = mainUrl,
+                subtitleCallback = subtitleCallback,
+                callback = callback
+            )
+        }
+
         return true
     }
 }

--- a/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnityPlugin.kt
+++ b/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnityPlugin.kt
@@ -32,11 +32,20 @@ class AnimeUnityPlugin : Plugin() {
         const val PREF_UPCOMING_COUNT = "upcomingCount"
         const val PREF_RANDOM_COUNT = "randomCount"
 
+        // Nomi personalizzati per sezione
+        const val PREF_LATEST_TITLE = "latestTitle"
+        const val PREF_CALENDAR_TITLE = "calendarTitle"
+        const val PREF_ONGOING_TITLE = "ongoingTitle"
+        const val PREF_POPULAR_TITLE = "popularTitle"
+        const val PREF_BEST_TITLE = "bestTitle"
+        const val PREF_UPCOMING_TITLE = "upcomingTitle"
+        const val PREF_RANDOM_TITLE = "randomTitle"
+
         // Visualizzazione
+        const val PREF_UNIFY_DUB_SUB_CARDS = "unifyDubSubCards"
         const val PREF_SHOW_DUB_SUB = "showDubSub"
         const val PREF_SHOW_EPISODE_NUMBER = "showEpisodeNumber"
         const val PREF_SHOW_SCORE = "showScore"
-
         const val PREF_SECTION_ORDER = "sectionOrder"
         const val PREF_ENABLE_ADVANCED_SEARCH = "enableAdvancedSearch"
         const val PREF_ADVANCED_SEARCH_TITLE = "advancedSearchTitle"
@@ -53,6 +62,7 @@ class AnimeUnityPlugin : Plugin() {
         const val MAX_SECTION_COUNT = 100
         const val DEFAULT_ADVANCED_SEARCH_COUNT = MAX_SECTION_COUNT
         const val DEFAULT_SECTION_ORDER = "latest,calendar,random,ongoing,popular,best,upcoming"
+        const val DEFAULT_UNIFY_DUB_SUB_CARDS = true
         private const val ARCHIVE_OLDEST_YEAR = 1966
         private val defaultSectionKeys = DEFAULT_SECTION_ORDER.split(",")
         private val validSectionKeys = listOf(
@@ -197,6 +207,24 @@ class AnimeUnityPlugin : Plugin() {
 
         fun getConfiguredSectionOrder(sharedPref: SharedPreferences?): String {
             return getValidatedSectionOrder(sharedPref?.getString(PREF_SECTION_ORDER, null))
+        }
+
+        fun getConfiguredSectionTitle(
+            sharedPref: SharedPreferences?,
+            prefKey: String,
+            fallback: String,
+        ): String {
+            return sharedPref?.getString(prefKey, null)
+                ?.trim()
+                ?.takeIf { it.isNotEmpty() }
+                ?: fallback
+        }
+
+        fun shouldUseUnifiedDubSubCards(sharedPref: SharedPreferences?): Boolean {
+            return sharedPref?.getBoolean(
+                PREF_UNIFY_DUB_SUB_CARDS,
+                DEFAULT_UNIFY_DUB_SUB_CARDS,
+            ) ?: DEFAULT_UNIFY_DUB_SUB_CARDS
         }
 
         fun getAdvancedSearchGenres(): List<ArchiveGenreOption> {

--- a/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnitySettings.kt
+++ b/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnitySettings.kt
@@ -5,8 +5,12 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.graphics.Color
 import android.graphics.drawable.Drawable
+import android.net.Uri
 import android.os.Bundle
+import android.text.SpannableStringBuilder
+import android.text.Spanned
 import android.text.Editable
+import android.text.style.ForegroundColorSpan
 import android.text.InputFilter
 import android.text.TextWatcher
 import android.view.LayoutInflater
@@ -142,6 +146,122 @@ class AnimeUnitySettings : AnimeUnityBaseSettingsFragment() {
 
     override val layoutName: String = "settings"
 
+    private fun buildFeedbackDialogMessage(): SpannableStringBuilder {
+        val message = SpannableStringBuilder(
+            getString("settings_feedback_message")
+                ?: "Vuoi segnalare un Problema o vuoi suggerire un Miglioramento?"
+        )
+
+        val problemText = getString("settings_feedback_problem_highlight") ?: "Problema"
+        val suggestionText =
+            getString("settings_feedback_suggestion_highlight") ?: "Miglioramento"
+
+        val problemIndex = message.indexOf(problemText)
+        if (problemIndex >= 0) {
+            message.setSpan(
+                ForegroundColorSpan(Color.parseColor("#FFFF7F7F")),
+                problemIndex,
+                problemIndex + problemText.length,
+                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
+        }
+
+        val suggestionIndex = message.indexOf(suggestionText)
+        if (suggestionIndex >= 0) {
+            message.setSpan(
+                ForegroundColorSpan(Color.parseColor("#FF7CFF9D")),
+                suggestionIndex,
+                suggestionIndex + suggestionText.length,
+                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
+        }
+
+        return message
+    }
+
+    private fun openFeedbackPage(titlePrefix: String) {
+        val context = context ?: return
+        val issuesUrl =
+            "https://github.com/doGior/doGiorsHadEnough/issues/new?title=${Uri.encode(titlePrefix)}"
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(issuesUrl))
+
+        runCatching { startActivity(intent) }
+            .onFailure {
+                showToast(
+                    getString("settings_feedback_unavailable")
+                        ?: "Impossibile aprire GitHub in questo momento."
+                )
+            }
+    }
+
+    private fun showFeedbackDialog() {
+        val context = context ?: return
+        val layoutId = plugin.resources?.getIdentifier(
+            "settings_feedback_dialog",
+            "layout",
+            BuildConfig.LIBRARY_PACKAGE_NAME
+        ) ?: return
+        val dialogView = layoutInflater.inflate(plugin.resources?.getLayout(layoutId), null, false)
+
+        dialogView.findViewByName<TextView>("feedback_dialog_title")?.text =
+            getString("settings_feedback_title") ?: "Segnalazioni e Suggerimenti"
+        dialogView.findViewByName<TextView>("feedback_dialog_message")?.text =
+            buildFeedbackDialogMessage()
+
+        val dialog = AlertDialog.Builder(context)
+            .setView(dialogView)
+            .create()
+
+        dialogView.findViewByName<TextView>("feedback_problem_btn")?.apply {
+            makeTvCompatible()
+            background = getDrawable("outline_danger")
+            setTextColor(Color.parseColor("#FFFF7F7F"))
+            text = getString("settings_feedback_problem_action") ?: "Segnala un Problema"
+            setOnClickListener {
+                dialog.dismiss()
+                openFeedbackPage("AnimeUnity [problema]: ")
+            }
+        }
+
+        dialogView.findViewByName<TextView>("feedback_suggestion_btn")?.apply {
+            makeTvCompatible()
+            background = getDrawable("outline_success")
+            setTextColor(Color.parseColor("#FF7CFF9D"))
+            text = getString("settings_feedback_suggestion_action")
+                ?: "Suggerisci un Miglioramento"
+            setOnClickListener {
+                dialog.dismiss()
+                openFeedbackPage("AnimeUnity [suggerimento]: ")
+            }
+        }
+
+        dialogView.findViewByName<TextView>("feedback_cancel_btn")?.apply {
+            makeTvCompatible()
+            background = getDrawable("outline")
+            setTextColor(Color.parseColor("#FFE6E6E6"))
+            text = getString("settings_feedback_cancel") ?: "Annulla"
+            setOnClickListener { dialog.dismiss() }
+        }
+
+        dialog.show()
+    }
+
+    private fun getBuildInfoText(): String? {
+        val rawCommit = BuildConfig.BUILD_COMMIT_SHA.trim()
+        val rawBuildCompletedAt = BuildConfig.BUILD_COMPLETED_AT_ROME.trim()
+        val shortCommit = rawCommit.takeIf { it.isNotEmpty() && it != "unknown" }?.take(7)
+            ?: return null
+
+        return if (rawBuildCompletedAt.isNotEmpty()) {
+            (getString("settings_build_info") ?: "Commit %1\$s | Build %2\$s").format(
+                shortCommit,
+                rawBuildCompletedAt
+            )
+        } else {
+            (getString("settings_build_info_commit_only") ?: "Commit %1\$s").format(shortCommit)
+        }
+    }
+
     private fun setupSiteUrlResetButton(
         button: ImageButton?,
         input: EditText?,
@@ -192,6 +312,11 @@ class AnimeUnitySettings : AnimeUnityBaseSettingsFragment() {
 
         view.findViewByName<TextView>("header_tw")?.text =
             getString("settings_menu_title")
+        view.findViewByName<TextView>("header_build_info")?.apply {
+            val buildInfoText = getBuildInfoText()
+            text = buildInfoText
+            visibility = if (buildInfoText.isNullOrBlank()) View.GONE else View.VISIBLE
+        }
         view.findViewByName<TextView>("home_settings_title")?.text =
             getString("settings_menu_home_title")
         view.findViewByName<TextView>("home_settings_summary")?.text =
@@ -221,6 +346,7 @@ class AnimeUnitySettings : AnimeUnityBaseSettingsFragment() {
         val siteUrlContainer: View? = view.findViewByName("site_url_container")
         val siteUrlInput: EditText? = view.findViewByName("site_url_input")
         val siteUrlClear: ImageButton? = view.findViewByName("site_url_clear")
+        val reportFeedbackButton: TextView? = view.findViewByName("report_feedback_btn")
         val resetSettingsButton: TextView? = view.findViewByName("reset_settings_btn")
         val advancedSearchActionEnabledColor = advancedSearchAction?.currentTextColor ?: Color.WHITE
 
@@ -228,7 +354,10 @@ class AnimeUnitySettings : AnimeUnityBaseSettingsFragment() {
             card?.makeTvCompatible()
         }
         siteUrlContainer?.applyOutlineBackground()
+        reportFeedbackButton?.makeTvCompatible()
         resetSettingsButton?.makeTvCompatible()
+        reportFeedbackButton?.background = getDrawable("outline_feedback")
+        reportFeedbackButton?.setTextColor(Color.parseColor("#FF9ED0FF"))
         resetSettingsButton?.background = getDrawable("outline_danger")
         resetSettingsButton?.setTextColor(Color.parseColor("#FFFF7F7F"))
 
@@ -243,6 +372,7 @@ class AnimeUnitySettings : AnimeUnityBaseSettingsFragment() {
             advancedSearchActionEnabledColor,
             advancedSearchSwitch?.isChecked == true
         )
+        reportFeedbackButton?.text = getString("settings_feedback_button")
         resetSettingsButton?.text = getString("settings_reset_button")
         siteUrlInput?.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) = Unit
@@ -312,6 +442,10 @@ class AnimeUnitySettings : AnimeUnityBaseSettingsFragment() {
                 .show()
         }
 
+        reportFeedbackButton?.setOnClickListener {
+            showFeedbackDialog()
+        }
+
         homeSettingsCard?.setOnClickListener {
             AnimeUnityHomeSettingsFragment().show(
                 parentFragmentManager,
@@ -345,10 +479,20 @@ class AnimeUnityHomeSettingsFragment : AnimeUnityBaseSettingsFragment() {
         val key: String,
         val rowId: String,
         val labelStringName: String,
+        val titlePrefKey: String,
         val switchPrefKey: String,
         val countPrefKey: String?,
         val defaultEnabled: Boolean = true,
     )
+
+    private fun getSectionTitle(sectionRow: SectionRow): String {
+        val defaultTitle = getString(sectionRow.labelStringName).orEmpty()
+        return AnimeUnityPlugin.getConfiguredSectionTitle(
+            sharedPref,
+            sectionRow.titlePrefKey,
+            defaultTitle,
+        )
+    }
 
     private fun getCount(prefKey: String): Int {
         return (sharedPref?.getInt(prefKey, AnimeUnityPlugin.DEFAULT_SECTION_COUNT)
@@ -444,6 +588,7 @@ class AnimeUnityHomeSettingsFragment : AnimeUnityBaseSettingsFragment() {
                 key = "latest",
                 rowId = "latest_row",
                 labelStringName = "latest_count_label",
+                titlePrefKey = AnimeUnityPlugin.PREF_LATEST_TITLE,
                 switchPrefKey = AnimeUnityPlugin.PREF_SHOW_LATEST_EPISODES,
                 countPrefKey = AnimeUnityPlugin.PREF_LATEST_COUNT,
             ),
@@ -451,6 +596,7 @@ class AnimeUnityHomeSettingsFragment : AnimeUnityBaseSettingsFragment() {
                 key = "calendar",
                 rowId = "calendar_row",
                 labelStringName = "calendar_switch_text",
+                titlePrefKey = AnimeUnityPlugin.PREF_CALENDAR_TITLE,
                 switchPrefKey = AnimeUnityPlugin.PREF_SHOW_CALENDAR,
                 countPrefKey = AnimeUnityPlugin.PREF_CALENDAR_COUNT,
             ),
@@ -458,6 +604,7 @@ class AnimeUnityHomeSettingsFragment : AnimeUnityBaseSettingsFragment() {
                 key = "ongoing",
                 rowId = "ongoing_row",
                 labelStringName = "ongoing_count_label",
+                titlePrefKey = AnimeUnityPlugin.PREF_ONGOING_TITLE,
                 switchPrefKey = AnimeUnityPlugin.PREF_SHOW_ONGOING,
                 countPrefKey = AnimeUnityPlugin.PREF_ONGOING_COUNT,
             ),
@@ -465,6 +612,7 @@ class AnimeUnityHomeSettingsFragment : AnimeUnityBaseSettingsFragment() {
                 key = "popular",
                 rowId = "popular_row",
                 labelStringName = "popular_count_label",
+                titlePrefKey = AnimeUnityPlugin.PREF_POPULAR_TITLE,
                 switchPrefKey = AnimeUnityPlugin.PREF_SHOW_POPULAR,
                 countPrefKey = AnimeUnityPlugin.PREF_POPULAR_COUNT,
             ),
@@ -472,6 +620,7 @@ class AnimeUnityHomeSettingsFragment : AnimeUnityBaseSettingsFragment() {
                 key = "best",
                 rowId = "best_row",
                 labelStringName = "best_count_label",
+                titlePrefKey = AnimeUnityPlugin.PREF_BEST_TITLE,
                 switchPrefKey = AnimeUnityPlugin.PREF_SHOW_BEST,
                 countPrefKey = AnimeUnityPlugin.PREF_BEST_COUNT,
             ),
@@ -479,6 +628,7 @@ class AnimeUnityHomeSettingsFragment : AnimeUnityBaseSettingsFragment() {
                 key = "upcoming",
                 rowId = "upcoming_row",
                 labelStringName = "upcoming_count_label",
+                titlePrefKey = AnimeUnityPlugin.PREF_UPCOMING_TITLE,
                 switchPrefKey = AnimeUnityPlugin.PREF_SHOW_UPCOMING,
                 countPrefKey = AnimeUnityPlugin.PREF_UPCOMING_COUNT,
             ),
@@ -486,6 +636,7 @@ class AnimeUnityHomeSettingsFragment : AnimeUnityBaseSettingsFragment() {
                 key = "random",
                 rowId = "random_row",
                 labelStringName = "random_count_label",
+                titlePrefKey = AnimeUnityPlugin.PREF_RANDOM_TITLE,
                 switchPrefKey = AnimeUnityPlugin.PREF_SHOW_RANDOM,
                 countPrefKey = AnimeUnityPlugin.PREF_RANDOM_COUNT,
             ),
@@ -504,8 +655,11 @@ class AnimeUnityHomeSettingsFragment : AnimeUnityBaseSettingsFragment() {
             val rowView = rowViewByKey.getValue(sectionRow.key)
             rowView.applyOutlineBackground()
 
-            rowView.findViewByName<TextView>("row_label")?.text =
-                getString(sectionRow.labelStringName)
+            rowView.findViewByName<EditText>("row_label")?.apply {
+                setText(getSectionTitle(sectionRow))
+                setSelection(text.length)
+                hint = getString(sectionRow.labelStringName)
+            }
 
             val switchView = rowView.findViewByName<Switch>("row_switch")
             switchView?.text = ""
@@ -561,6 +715,14 @@ class AnimeUnityHomeSettingsFragment : AnimeUnityBaseSettingsFragment() {
                             parseCount(rowView.findViewByName("row_count_input"))
                         )
                     }
+
+                    val titleInput = rowView.findViewByName<EditText>("row_label")
+                    val trimmedTitle = titleInput?.text?.toString()?.trim().orEmpty()
+                    if (trimmedTitle.isEmpty()) {
+                        remove(sectionRow.titlePrefKey)
+                    } else {
+                        putString(sectionRow.titlePrefKey, trimmedTitle)
+                    }
                 }
             }
 
@@ -592,8 +754,19 @@ class AnimeUnityDisplaySettingsFragment : AnimeUnityBaseSettingsFragment() {
 
         view.findViewByName<TextView>("header_tw")?.text =
             getString("settings_display_title")
+        view.findViewByName<View>("display_options_card")?.applyOutlineBackground()
+        view.findViewByName<TextView>("display_options_title")?.text =
+            getString("display_options_title")
 
         val switchSettings = listOf(
+            SwitchSetting(
+                AnimeUnityPlugin.PREF_UNIFY_DUB_SUB_CARDS,
+                "unify_dub_sub_cards_row",
+                "unify_dub_sub_cards_label",
+                "unify_dub_sub_cards_switch",
+                "unify_dub_sub_cards_switch_text",
+                AnimeUnityPlugin.DEFAULT_UNIFY_DUB_SUB_CARDS,
+            ),
             SwitchSetting(
                 AnimeUnityPlugin.PREF_SHOW_DUB_SUB,
                 "dub_sub_row",

--- a/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/VixCloudExtractor.kt
+++ b/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/VixCloudExtractor.kt
@@ -9,7 +9,10 @@ import com.lagradost.cloudstream3.utils.ExtractorLinkType
 import com.lagradost.cloudstream3.utils.newExtractorLink
 import org.json.JSONObject
 
-class VixCloudExtractor : ExtractorApi() {
+class VixCloudExtractor(
+    private val sourceName: String = "VixCloud",
+    private val displayName: String = "AnimeUnity",
+) : ExtractorApi() {
     override val mainUrl = "vixcloud.co"
     override val name = "VixCloud"
     override val requiresReferer = false
@@ -34,8 +37,8 @@ class VixCloudExtractor : ExtractorApi() {
 
         callback.invoke(
             newExtractorLink(
-                source = "VixCloud",
-                name = "AnimeUnity",
+                source = sourceName,
+                name = displayName,
                 url = playlistUrl,
                 type = ExtractorLinkType.M3U8
             ) {

--- a/AnimeUnity/src/main/res/drawable/outline_feedback.xml
+++ b/AnimeUnity/src/main/res/drawable/outline_feedback.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:state_focused="true">
+        <shape android:shape="rectangle">
+            <solid android:color="#332F8FFF" />
+            <stroke
+                android:width="2dp"
+                android:color="#FF7AB8FF" />
+            <corners android:radius="8dp" />
+        </shape>
+    </item>
+
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="#222F8FFF" />
+            <stroke
+                android:width="2dp"
+                android:color="#CC7AB8FF" />
+            <corners android:radius="8dp" />
+        </shape>
+    </item>
+
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="#142F8FFF" />
+            <stroke
+                android:width="2dp"
+                android:color="#997AB8FF" />
+            <corners android:radius="8dp" />
+        </shape>
+    </item>
+</selector>

--- a/AnimeUnity/src/main/res/drawable/outline_success.xml
+++ b/AnimeUnity/src/main/res/drawable/outline_success.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:state_focused="true">
+        <shape android:shape="rectangle">
+            <solid android:color="#332AC96B" />
+            <stroke
+                android:width="2dp"
+                android:color="#FF7CFF9D" />
+            <corners android:radius="8dp" />
+        </shape>
+    </item>
+
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="#222AC96B" />
+            <stroke
+                android:width="2dp"
+                android:color="#CC7CFF9D" />
+            <corners android:radius="8dp" />
+        </shape>
+    </item>
+
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="#142AC96B" />
+            <stroke
+                android:width="2dp"
+                android:color="#997CFF9D" />
+            <corners android:radius="8dp" />
+        </shape>
+    </item>
+</selector>

--- a/AnimeUnity/src/main/res/layout/settings.xml
+++ b/AnimeUnity/src/main/res/layout/settings.xml
@@ -7,16 +7,36 @@
 
     <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="48dp">
+        android:layout_height="wrap_content"
+        android:minHeight="56dp"
+        android:paddingVertical="4dp">
 
-        <TextView
-            android:id="@+id/header_tw"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:id="@+id/header_text_container"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_alignParentStart="true"
             android:layout_centerVertical="true"
-            android:textSize="24sp"
-            android:textStyle="bold" />
+            android:layout_toStartOf="@id/save_btn"
+            android:layout_marginEnd="12dp"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/header_tw"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="24sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/header_build_info"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:alpha="0.78"
+                android:maxLines="2"
+                android:textSize="12sp" />
+        </LinearLayout>
 
         <ImageButton
             android:id="@+id/save_btn"
@@ -202,17 +222,40 @@
             android:scaleType="centerInside" />
     </LinearLayout>
 
-    <TextView
-        android:id="@+id/reset_settings_btn"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:id="@+id/footer_actions_row"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="12dp"
-        android:layout_gravity="center_horizontal"
-        android:clickable="true"
-        android:focusable="true"
         android:gravity="center"
-        android:minHeight="52dp"
-        android:paddingHorizontal="18dp"
-        android:paddingVertical="14dp"
-        android:textStyle="bold" />
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/report_feedback_btn"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:layout_weight="1"
+            android:clickable="true"
+            android:focusable="true"
+            android:gravity="center"
+            android:minHeight="52dp"
+            android:paddingHorizontal="18dp"
+            android:paddingVertical="14dp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/reset_settings_btn"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_weight="1"
+            android:clickable="true"
+            android:focusable="true"
+            android:gravity="center"
+            android:minHeight="52dp"
+            android:paddingHorizontal="18dp"
+            android:paddingVertical="14dp"
+            android:textStyle="bold" />
+    </LinearLayout>
 </LinearLayout>

--- a/AnimeUnity/src/main/res/layout/settings_display.xml
+++ b/AnimeUnity/src/main/res/layout/settings_display.xml
@@ -3,11 +3,11 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:padding="4dp">
+    android:padding="8dp">
 
     <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="42dp">
+        android:layout_height="48dp">
 
         <TextView
             android:id="@+id/header_tw"
@@ -15,13 +15,13 @@
             android:layout_height="wrap_content"
             android:layout_alignParentStart="true"
             android:layout_centerVertical="true"
-            android:textSize="22sp"
+            android:textSize="24sp"
             android:textStyle="bold" />
 
         <ImageButton
             android:id="@+id/save_btn"
-            android:layout_width="44dp"
-            android:layout_height="44dp"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
             android:layout_alignParentEnd="true"
             android:layout_centerVertical="true"
             android:background="@android:color/transparent"
@@ -29,99 +29,149 @@
     </RelativeLayout>
 
     <LinearLayout
-        android:id="@+id/display_rows_container"
+        android:id="@+id/display_options_card"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="2dp"
-        android:orientation="vertical">
+        android:layout_marginTop="8dp"
+        android:orientation="vertical"
+        android:padding="14dp">
 
-        <LinearLayout
-            android:id="@+id/dub_sub_row"
+        <TextView
+            android:id="@+id/display_options_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="2dp"
-            android:gravity="center_vertical"
-            android:orientation="horizontal"
-            android:paddingStart="4dp"
-            android:paddingTop="2dp"
-            android:paddingEnd="4dp"
-            android:paddingBottom="2dp">
-
-            <TextView
-                android:id="@+id/dub_sub_label"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:textSize="12sp"
-                android:textStyle="bold" />
-
-            <Switch
-                android:id="@+id/dub_sub_switch"
-                android:layout_width="42dp"
-                android:layout_height="wrap_content"
-                android:minHeight="0dp"
-                android:showText="false"
-                android:switchMinWidth="28dp"
-                android:text="" />
-        </LinearLayout>
+            android:textSize="17sp"
+            android:textStyle="bold" />
 
         <LinearLayout
-            android:id="@+id/episode_number_row"
+            android:id="@+id/display_rows_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="2dp"
-            android:gravity="center_vertical"
-            android:orientation="horizontal"
-            android:paddingStart="4dp"
-            android:paddingTop="2dp"
-            android:paddingEnd="4dp"
-            android:paddingBottom="2dp">
+            android:layout_marginTop="8dp"
+            android:orientation="vertical">
 
-            <TextView
-                android:id="@+id/episode_number_label"
-                android:layout_width="0dp"
+            <LinearLayout
+                android:id="@+id/unify_dub_sub_cards_row"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:textSize="12sp"
-                android:textStyle="bold" />
+                android:gravity="center_vertical"
+                android:minHeight="52dp"
+                android:orientation="horizontal"
+                android:paddingStart="12dp"
+                android:paddingTop="10dp"
+                android:paddingEnd="12dp"
+                android:paddingBottom="10dp">
 
-            <Switch
-                android:id="@+id/episode_number_switch"
-                android:layout_width="42dp"
+                <TextView
+                    android:id="@+id/unify_dub_sub_cards_label"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:textSize="13sp"
+                    android:textStyle="bold" />
+
+                <Switch
+                    android:id="@+id/unify_dub_sub_cards_switch"
+                    android:layout_width="42dp"
+                    android:layout_height="wrap_content"
+                    android:minHeight="0dp"
+                    android:showText="false"
+                    android:switchMinWidth="28dp"
+                    android:text="" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/dub_sub_row"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:minHeight="0dp"
-                android:showText="false"
-                android:switchMinWidth="28dp"
-                android:text="" />
-        </LinearLayout>
+                android:layout_marginTop="8dp"
+                android:gravity="center_vertical"
+                android:minHeight="52dp"
+                android:orientation="horizontal"
+                android:paddingStart="12dp"
+                android:paddingTop="10dp"
+                android:paddingEnd="12dp"
+                android:paddingBottom="10dp">
 
-        <LinearLayout
-            android:id="@+id/score_row"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical"
-            android:orientation="horizontal"
-            android:paddingStart="4dp"
-            android:paddingTop="2dp"
-            android:paddingEnd="4dp"
-            android:paddingBottom="2dp">
+                <TextView
+                    android:id="@+id/dub_sub_label"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:textSize="13sp"
+                    android:textStyle="bold" />
 
-            <TextView
-                android:id="@+id/score_label"
-                android:layout_width="0dp"
+                <Switch
+                    android:id="@+id/dub_sub_switch"
+                    android:layout_width="42dp"
+                    android:layout_height="wrap_content"
+                    android:minHeight="0dp"
+                    android:showText="false"
+                    android:switchMinWidth="28dp"
+                    android:text="" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/episode_number_row"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:textSize="12sp"
-                android:textStyle="bold" />
+                android:layout_marginTop="8dp"
+                android:gravity="center_vertical"
+                android:minHeight="52dp"
+                android:orientation="horizontal"
+                android:paddingStart="12dp"
+                android:paddingTop="10dp"
+                android:paddingEnd="12dp"
+                android:paddingBottom="10dp">
 
-            <Switch
-                android:id="@+id/score_switch"
-                android:layout_width="42dp"
+                <TextView
+                    android:id="@+id/episode_number_label"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:textSize="13sp"
+                    android:textStyle="bold" />
+
+                <Switch
+                    android:id="@+id/episode_number_switch"
+                    android:layout_width="42dp"
+                    android:layout_height="wrap_content"
+                    android:minHeight="0dp"
+                    android:showText="false"
+                    android:switchMinWidth="28dp"
+                    android:text="" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/score_row"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:minHeight="0dp"
-                android:showText="false"
-                android:switchMinWidth="28dp"
-                android:text="" />
+                android:layout_marginTop="8dp"
+                android:gravity="center_vertical"
+                android:minHeight="52dp"
+                android:orientation="horizontal"
+                android:paddingStart="12dp"
+                android:paddingTop="10dp"
+                android:paddingEnd="12dp"
+                android:paddingBottom="10dp">
+
+                <TextView
+                    android:id="@+id/score_label"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:textSize="13sp"
+                    android:textStyle="bold" />
+
+                <Switch
+                    android:id="@+id/score_switch"
+                    android:layout_width="42dp"
+                    android:layout_height="wrap_content"
+                    android:minHeight="0dp"
+                    android:showText="false"
+                    android:switchMinWidth="28dp"
+                    android:text="" />
+            </LinearLayout>
         </LinearLayout>
     </LinearLayout>
 </LinearLayout>

--- a/AnimeUnity/src/main/res/layout/settings_feedback_dialog.xml
+++ b/AnimeUnity/src/main/res/layout/settings_feedback_dialog.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/feedback_dialog_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="22sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/feedback_dialog_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="14dp"
+        android:lineSpacingExtra="2dp"
+        android:textSize="17sp" />
+
+    <LinearLayout
+        android:id="@+id/feedback_dialog_actions_row"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:baselineAligned="false"
+        android:gravity="center"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/feedback_problem_btn"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_marginEnd="8dp"
+            android:layout_weight="1"
+            android:clickable="true"
+            android:focusable="true"
+            android:gravity="center"
+            android:maxLines="2"
+            android:minHeight="54dp"
+            android:paddingHorizontal="16dp"
+            android:paddingVertical="14dp"
+            android:singleLine="false"
+            android:textAlignment="center"
+            android:textSize="14sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/feedback_suggestion_btn"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_marginStart="8dp"
+            android:layout_weight="1"
+            android:clickable="true"
+            android:focusable="true"
+            android:gravity="center"
+            android:maxLines="2"
+            android:minHeight="54dp"
+            android:paddingHorizontal="16dp"
+            android:paddingVertical="14dp"
+            android:singleLine="false"
+            android:textAlignment="center"
+            android:textSize="14sp"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/feedback_cancel_btn"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="14dp"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center"
+        android:minHeight="48dp"
+        android:minWidth="132dp"
+        android:paddingHorizontal="18dp"
+        android:paddingVertical="12dp"
+        android:textStyle="bold" />
+</LinearLayout>

--- a/AnimeUnity/src/main/res/layout/settings_home.xml
+++ b/AnimeUnity/src/main/res/layout/settings_home.xml
@@ -89,11 +89,18 @@
             android:paddingEnd="4dp"
             android:paddingBottom="4dp">
 
-            <TextView
+            <EditText
                 android:id="@+id/row_label"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
+                android:background="@android:color/transparent"
+                android:gravity="start|center_vertical"
+                android:imeOptions="actionDone"
+                android:maxLines="1"
+                android:paddingTop="2dp"
+                android:paddingBottom="2dp"
+                android:singleLine="true"
                 android:textSize="12sp"
                 android:textStyle="bold" />
 
@@ -149,11 +156,18 @@
             android:paddingEnd="4dp"
             android:paddingBottom="4dp">
 
-            <TextView
+            <EditText
                 android:id="@+id/row_label"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
+                android:background="@android:color/transparent"
+                android:gravity="start|center_vertical"
+                android:imeOptions="actionDone"
+                android:maxLines="1"
+                android:paddingTop="2dp"
+                android:paddingBottom="2dp"
+                android:singleLine="true"
                 android:textSize="12sp"
                 android:textStyle="bold" />
 
@@ -209,11 +223,18 @@
             android:paddingEnd="4dp"
             android:paddingBottom="4dp">
 
-            <TextView
+            <EditText
                 android:id="@+id/row_label"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
+                android:background="@android:color/transparent"
+                android:gravity="start|center_vertical"
+                android:imeOptions="actionDone"
+                android:maxLines="1"
+                android:paddingTop="2dp"
+                android:paddingBottom="2dp"
+                android:singleLine="true"
                 android:textSize="12sp"
                 android:textStyle="bold" />
 
@@ -269,11 +290,18 @@
             android:paddingEnd="4dp"
             android:paddingBottom="4dp">
 
-            <TextView
+            <EditText
                 android:id="@+id/row_label"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
+                android:background="@android:color/transparent"
+                android:gravity="start|center_vertical"
+                android:imeOptions="actionDone"
+                android:maxLines="1"
+                android:paddingTop="2dp"
+                android:paddingBottom="2dp"
+                android:singleLine="true"
                 android:textSize="12sp"
                 android:textStyle="bold" />
 
@@ -329,11 +357,18 @@
             android:paddingEnd="4dp"
             android:paddingBottom="4dp">
 
-            <TextView
+            <EditText
                 android:id="@+id/row_label"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
+                android:background="@android:color/transparent"
+                android:gravity="start|center_vertical"
+                android:imeOptions="actionDone"
+                android:maxLines="1"
+                android:paddingTop="2dp"
+                android:paddingBottom="2dp"
+                android:singleLine="true"
                 android:textSize="12sp"
                 android:textStyle="bold" />
 
@@ -389,11 +424,18 @@
             android:paddingEnd="4dp"
             android:paddingBottom="4dp">
 
-            <TextView
+            <EditText
                 android:id="@+id/row_label"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
+                android:background="@android:color/transparent"
+                android:gravity="start|center_vertical"
+                android:imeOptions="actionDone"
+                android:maxLines="1"
+                android:paddingTop="2dp"
+                android:paddingBottom="2dp"
+                android:singleLine="true"
                 android:textSize="12sp"
                 android:textStyle="bold" />
 
@@ -449,11 +491,18 @@
             android:paddingEnd="4dp"
             android:paddingBottom="4dp">
 
-            <TextView
+            <EditText
                 android:id="@+id/row_label"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
+                android:background="@android:color/transparent"
+                android:gravity="start|center_vertical"
+                android:imeOptions="actionDone"
+                android:maxLines="1"
+                android:paddingTop="2dp"
+                android:paddingBottom="2dp"
+                android:singleLine="true"
                 android:textSize="12sp"
                 android:textStyle="bold" />
 

--- a/AnimeUnity/src/main/res/values/strings.xml
+++ b/AnimeUnity/src/main/res/values/strings.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="settings_menu_title">AnimeUnity</string>
+    <string name="settings_build_info">Commit %1$s | Build %2$s</string>
+    <string name="settings_build_info_commit_only">Commit %1$s</string>
     <string name="settings_menu_home_title">Home</string>
     <string name="settings_menu_home_summary">Personalizza Home</string>
-    <string name="settings_menu_display_title">Visualizzazione</string>
-    <string name="settings_menu_display_summary">Personalizza Scheda Anime</string>
+    <string name="settings_menu_display_title">Preferenze</string>
+    <string name="settings_menu_display_summary">Schede e dettagli anime</string>
     <string name="settings_menu_advanced_search_title">Ricerca avanzata</string>
     <string name="settings_menu_advanced_search_summary">Ricerca Anime per criteri</string>
     <string name="settings_open_action">Apri</string>
@@ -35,9 +37,11 @@
     <string name="upcoming_count_label">In arrivo</string>
     <string name="random_count_label">Random</string>
 
-    <string name="settings_display_title">Visualizzazione</string>
+    <string name="settings_display_title">Preferenze</string>
     <string name="settings_advanced_search_title">Ricerca avanzata</string>
-    <string name="dub_sub_switch_text">SUB/DUB</string>
+    <string name="unify_dub_sub_cards_switch_text">Scheda unica SUB/DUB</string>
+    <string name="dub_sub_switch_text">SUB / DUB</string>
+    <string name="display_options_title">Dettagli scheda</string>
     <string name="episode_number_switch_text">Numero episodio</string>
     <string name="score_switch_text">Valutazione</string>
     <string name="advanced_search_name_label">Nome</string>
@@ -66,6 +70,15 @@
     <string name="settings_restart_title">Riavvia applicazione</string>
     <string name="settings_saved_restart_message">Impostazioni salvate. Vuoi riavviare l\'applicazione ora per applicare subito le modifiche?</string>
     <string name="site_url_fallback_restart_message">Link non valido: verra usato quello predefinito. Vuoi riavviare l\'applicazione ora per applicare subito le modifiche?</string>
+    <string name="settings_feedback_button">Segnalazioni e Suggerimenti</string>
+    <string name="settings_feedback_title">Segnalazioni e Suggerimenti</string>
+    <string name="settings_feedback_message">Vuoi segnalare un Problema o vuoi suggerire un Miglioramento?</string>
+    <string name="settings_feedback_problem_highlight">Problema</string>
+    <string name="settings_feedback_suggestion_highlight">Miglioramento</string>
+    <string name="settings_feedback_problem_action">Segnala un Problema</string>
+    <string name="settings_feedback_suggestion_action">Suggerisci un Miglioramento</string>
+    <string name="settings_feedback_cancel">Annulla</string>
+    <string name="settings_feedback_unavailable">Impossibile aprire GitHub in questo momento.</string>
     <string name="settings_reset_button">Ripristina valori predefiniti</string>
     <string name="settings_reset_title">Ripristina impostazioni</string>
     <string name="settings_reset_message">Vuoi ripristinare tutti i valori di AnimeUnity a quelli predefiniti?</string>


### PR DESCRIPTION
### AnimeUnity
- aggiunta la possibilità di unificare le schede `SUB` e `DUB` in un’unica scheda, con caricamento di entrambe le versioni nella stessa pagina anime
- aggiunta la possibilità di cambiare sorgente direttamente nel player, passando tra `SUB` e `DUB` quando entrambe sono disponibili
- aggiunta la possibilità di personalizzare il nome delle varie sezioni della Home
- aggiunta la visualizzazione del commit e della data/ora dell’ultima build della GitHub Action nel menu impostazioni
- aggiunto un pulsante nelle impostazioni che reindirizza direttamente alla pagina `Issues` per segnalare problemi o proporre miglioramenti

### Nota tecnica
CloudStream, sembra, non gestire correttamente il cambio tra `SUB` e `DUB` quando il numero totale degli episodi non coincide tra le due versioni.  
Per aggirare il problema, quando gli episodi doppiati non corrispondono agli episodi con sottotitoli, vengono generati episodi “placeholder” nella sezione `DUB` in modo da mantenere l’allineamento con la lista `SUB`.

In questi casi:
- l’episodio continua ad apparire anche nella lista `DUB`
- viene caricato automaticamente l’episodio `SUB`
- gli episodi "placeholder" possono essere riconosciuto con il prefisso [SUB] -` davanti al titolo
