### PR TITLE
AnimeUnity: migliorie

### DIFF
--- a/AnimeUnity/build.gradle.kts
+++ b/AnimeUnity/build.gradle.kts
@@ -32,7 +32,7 @@ val buildCommitSha = resolveBuildCommitSha()
 val buildCompletedAtRome = resolveBuildCompletedAtRome()
 
 // use an integer for version numbers
-version = 21
+version = 23
 
 
 cloudstream {

--- a/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnity.kt
+++ b/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnity.kt
@@ -7,6 +7,7 @@ import com.lagradost.cloudstream3.HomePageResponse
 import com.lagradost.cloudstream3.LoadResponse
 import com.lagradost.cloudstream3.LoadResponse.Companion.addAniListId
 import com.lagradost.cloudstream3.LoadResponse.Companion.addDuration
+import com.lagradost.cloudstream3.LoadResponse.Companion.addKitsuId
 import com.lagradost.cloudstream3.LoadResponse.Companion.addMalId
 import com.lagradost.cloudstream3.LoadResponse.Companion.addScore
 import com.lagradost.cloudstream3.LoadResponse.Companion.addTrailer
@@ -19,18 +20,32 @@ import com.lagradost.cloudstream3.SearchResponse
 import com.lagradost.cloudstream3.ShowStatus
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.TvType
+import com.lagradost.cloudstream3.addDate
+import com.lagradost.cloudstream3.addDub
 import com.lagradost.cloudstream3.addDubStatus
 import com.lagradost.cloudstream3.addEpisodes
 import com.lagradost.cloudstream3.addPoster
-import com.lagradost.cloudstream3.amap
+import com.lagradost.cloudstream3.addSub
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.mainPageOf
 import com.lagradost.cloudstream3.newAnimeLoadResponse
 import com.lagradost.cloudstream3.newAnimeSearchResponse
 import com.lagradost.cloudstream3.newEpisode
 import com.lagradost.cloudstream3.newHomePageResponse
+import com.lagradost.cloudstream3.syncproviders.SyncIdName
 import com.lagradost.cloudstream3.utils.AppUtils.parseJson
+import com.lagradost.cloudstream3.utils.AppUtils.toJson
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.sync.Semaphore
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.jsoup.nodes.Element
 import java.text.Normalizer
@@ -53,6 +68,51 @@ class AnimeUnity(
     override var supportedTypes = setOf(TvType.Anime, TvType.AnimeMovie, TvType.OVA)
     override var lang = "it"
     override val hasMainPage = true
+    override val supportedSyncNames = setOf(
+        SyncIdName.Anilist,
+        SyncIdName.MyAnimeList,
+    )
+
+    private class ExpiringMemoryCache<K, V>(
+        private val ttlMs: Long,
+        private val maxSize: Int,
+    ) {
+        private data class Entry<V>(
+            val value: V,
+            val timestampMs: Long,
+        )
+
+        private val values = object : LinkedHashMap<K, Entry<V>>(maxSize, 0.75f, true) {
+            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<K, Entry<V>>?): Boolean {
+                return size > maxSize
+            }
+        }
+
+        fun get(key: K): V? {
+            val now = System.currentTimeMillis()
+            synchronized(values) {
+                val entry = values[key] ?: return null
+                if (now - entry.timestampMs > ttlMs) {
+                    values.remove(key)
+                    return null
+                }
+
+                return entry.value
+            }
+        }
+
+        fun put(key: K, value: V) {
+            synchronized(values) {
+                values[key] = Entry(value, System.currentTimeMillis())
+            }
+        }
+
+        fun clear() {
+            synchronized(values) {
+                values.clear()
+            }
+        }
+    }
 
     companion object {
         @Suppress("ConstPropertyName")
@@ -66,12 +126,138 @@ class AnimeUnity(
         const val popularSectionName = "Popolari"
         const val bestSectionName = "I migliori"
         const val upcomingSectionName = "In Arrivo"
+        const val noEpisodeDescription = "Nessuna descrizione"
         
         var name = "AnimeUnity"
         var headers = mapOf(
             "Host" to mainUrl.toHttpUrl().host,
             "User-Agent" to "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0"
         ).toMutableMap()
+
+        private const val CACHE_SCHEMA = "animeunity-v2"
+        private const val MINUTE_MS = 60 * 1000L
+        private const val HOUR_MS = 60 * MINUTE_MS
+        private const val DAY_MS = 24 * HOUR_MS
+        private const val LATEST_CACHE_TTL_MS = 30 * MINUTE_MS
+        private const val HOME_DYNAMIC_CACHE_TTL_MS = 2 * DAY_MS
+        private const val HOME_STATIC_CACHE_TTL_MS = 7 * DAY_MS
+        private const val DETAIL_ONGOING_CACHE_TTL_MS = DAY_MS
+        private const val DETAIL_COMPLETED_CACHE_TTL_MS = 14 * DAY_MS
+        private const val EXTERNAL_CACHE_TTL_MS = 24 * HOUR_MS
+        private const val SESSION_HEADERS_CACHE_TTL_MS = 15 * HOUR_MS
+        private const val PLAYER_EMBED_CACHE_TTL_MS = HOUR_MS
+        private const val CACHE_PRIORITY_VOLATILE = 0
+        private const val CACHE_PRIORITY_STANDARD = 1
+        private const val CACHE_PRIORITY_IMPORTANT = 2
+        private const val CACHE_PRIORITY_DETAIL = 3
+
+        private val archiveBatchCache =
+            ExpiringMemoryCache<String, ApiResponse>(HOME_DYNAMIC_CACHE_TTL_MS, 256)
+        private val animePageDataCache =
+            ExpiringMemoryCache<String, AnimePageData>(DETAIL_ONGOING_CACHE_TTL_MS, 128)
+        private val animeLoadDataCache =
+            ExpiringMemoryCache<String, AnimeLoadCacheData>(DETAIL_ONGOING_CACHE_TTL_MS, 64)
+        private val aniZipMetadataCache =
+            ExpiringMemoryCache<String, AniZipMetadata>(EXTERNAL_CACHE_TTL_MS, 128)
+        private val anilistPosterCache =
+            ExpiringMemoryCache<Int, String>(EXTERNAL_CACHE_TTL_MS, 256)
+        private val trailerUrlCache =
+            ExpiringMemoryCache<String, String>(EXTERNAL_CACHE_TTL_MS, 128)
+        private val playerEmbedUrlCache =
+            ExpiringMemoryCache<String, String>(PLAYER_EMBED_CACHE_TTL_MS, 256)
+        private val revalidatingKeys = mutableSetOf<String>()
+        private val randomSessionSeenIds = mutableMapOf<String, MutableSet<Int>>()
+        private val homeSectionConfigs = listOf(
+            HomeSectionConfig(
+                key = AnimeUnitySections.LATEST,
+                path = "",
+                enabledPrefKey = AnimeUnityPlugin.PREF_SHOW_LATEST_EPISODES,
+                titlePrefKey = AnimeUnityPlugin.PREF_LATEST_TITLE,
+                defaultTitle = latestEpisodesSectionName,
+                countPrefKey = AnimeUnityPlugin.PREF_LATEST_COUNT,
+            ),
+            HomeSectionConfig(
+                key = AnimeUnitySections.CALENDAR,
+                path = "calendario",
+                enabledPrefKey = AnimeUnityPlugin.PREF_SHOW_CALENDAR,
+                titlePrefKey = AnimeUnityPlugin.PREF_CALENDAR_TITLE,
+                defaultTitle = calendarSectionName,
+                countPrefKey = AnimeUnityPlugin.PREF_CALENDAR_COUNT,
+            ),
+            HomeSectionConfig(
+                key = AnimeUnitySections.ONGOING,
+                path = "archivio/",
+                enabledPrefKey = AnimeUnityPlugin.PREF_SHOW_ONGOING,
+                titlePrefKey = AnimeUnityPlugin.PREF_ONGOING_TITLE,
+                defaultTitle = ongoingSectionName,
+                countPrefKey = AnimeUnityPlugin.PREF_ONGOING_COUNT,
+            ),
+            HomeSectionConfig(
+                key = AnimeUnitySections.POPULAR,
+                path = "archivio/",
+                enabledPrefKey = AnimeUnityPlugin.PREF_SHOW_POPULAR,
+                titlePrefKey = AnimeUnityPlugin.PREF_POPULAR_TITLE,
+                defaultTitle = popularSectionName,
+                countPrefKey = AnimeUnityPlugin.PREF_POPULAR_COUNT,
+            ),
+            HomeSectionConfig(
+                key = AnimeUnitySections.BEST,
+                path = "archivio/",
+                enabledPrefKey = AnimeUnityPlugin.PREF_SHOW_BEST,
+                titlePrefKey = AnimeUnityPlugin.PREF_BEST_TITLE,
+                defaultTitle = bestSectionName,
+                countPrefKey = AnimeUnityPlugin.PREF_BEST_COUNT,
+            ),
+            HomeSectionConfig(
+                key = AnimeUnitySections.UPCOMING,
+                path = "archivio/",
+                enabledPrefKey = AnimeUnityPlugin.PREF_SHOW_UPCOMING,
+                titlePrefKey = AnimeUnityPlugin.PREF_UPCOMING_TITLE,
+                defaultTitle = upcomingSectionName,
+                countPrefKey = AnimeUnityPlugin.PREF_UPCOMING_COUNT,
+            ),
+            HomeSectionConfig(
+                key = AnimeUnitySections.RANDOM,
+                path = "archivio/",
+                enabledPrefKey = AnimeUnityPlugin.PREF_SHOW_RANDOM,
+                titlePrefKey = AnimeUnityPlugin.PREF_RANDOM_TITLE,
+                defaultTitle = randomSectionName,
+                countPrefKey = AnimeUnityPlugin.PREF_RANDOM_COUNT,
+                defaultCount = AnimeUnityPlugin.DEFAULT_RANDOM_COUNT,
+            ),
+        )
+        private val homeSectionConfigByKey = homeSectionConfigs.associateBy { it.key }
+        private val requestDataSectionKeys = setOf(
+            AnimeUnitySections.ADVANCED,
+            AnimeUnitySections.ONGOING,
+            AnimeUnitySections.POPULAR,
+            AnimeUnitySections.BEST,
+            AnimeUnitySections.UPCOMING,
+        )
+        private val staleWhileRevalidateSectionKeys = setOf(
+            AnimeUnitySections.LATEST,
+            AnimeUnitySections.ONGOING,
+            AnimeUnitySections.POPULAR,
+            AnimeUnitySections.BEST,
+            AnimeUnitySections.UPCOMING,
+        )
+
+        fun clearAllCaches() {
+            archiveBatchCache.clear()
+            animePageDataCache.clear()
+            animeLoadDataCache.clear()
+            aniZipMetadataCache.clear()
+            anilistPosterCache.clear()
+            trailerUrlCache.clear()
+            playerEmbedUrlCache.clear()
+            synchronized(revalidatingKeys) {
+                revalidatingKeys.clear()
+            }
+            synchronized(randomSessionSeenIds) {
+                randomSessionSeenIds.clear()
+            }
+            AnimeUnityCache.clear()
+        }
     }
 
     private data class ArchivePageResult(
@@ -84,15 +270,44 @@ class AnimeUnity(
         val baseUrl: String,
     )
 
+    private data class HomeSectionConfig(
+        val key: String,
+        val path: String,
+        val enabledPrefKey: String,
+        val titlePrefKey: String,
+        val defaultTitle: String,
+        val countPrefKey: String,
+        val defaultCount: Int = AnimeUnityPlugin.DEFAULT_SECTION_COUNT,
+    )
+
     private data class GroupedAnimeCard(
         val anime: Anime,
-        val hasDub: Boolean,
+        val badges: EpisodeBadgeState,
     )
 
     private data class GroupedLatestEpisodeCard(
         val anime: LatestEpisodeAnime,
-        val hasDub: Boolean,
+        val badges: EpisodeBadgeState,
         val episodeNumber: String,
+        val score: String?,
+    )
+
+    private data class CalendarAnimeItem(
+        val anime: Anime,
+        val episodeNumber: Int?,
+    )
+
+    private data class GroupedCalendarAnimeCard(
+        val anime: Anime,
+        val badges: EpisodeBadgeState,
+        val episodeNumber: Int?,
+    )
+
+    private data class EpisodeBadgeState(
+        val hasSub: Boolean,
+        val hasDub: Boolean,
+        val subEpisodeCount: Int? = null,
+        val dubEpisodeCount: Int? = null,
     )
 
     private data class AnimePageData(
@@ -106,10 +321,30 @@ class AnimeUnity(
         val url: String,
     )
 
+    private data class EpisodeMetadataIndex(
+        val byExactNumber: Map<String, AniZipEpisode>,
+        val byNormalizedNumber: Map<String, AniZipEpisode>,
+    )
+
     private data class EpisodePlaybackData(
         val preferredUrl: String,
         val subUrl: String?,
         val dubUrl: String?,
+    )
+
+    private data class AnimeLoadCacheData(
+        val currentPageData: AnimePageData,
+        val variants: List<Anime>,
+        val subPageData: AnimePageData?,
+        val dubPageData: AnimePageData?,
+        val episodeMetadata: AniZipMetadata?,
+        val trailerUrl: String?,
+        val fingerprint: String,
+    )
+
+    private data class SessionHeadersCacheData(
+        val headers: Map<String, String>,
+        val savedAtMs: Long,
     )
 
     private data class PlayerSourceOption(
@@ -137,51 +372,21 @@ class AnimeUnity(
     }
 
     private fun getSectionDisplayTitle(sectionKey: String): String {
-        return when (sectionKey) {
-            "latest" -> AnimeUnityPlugin.getConfiguredSectionTitle(
-                sharedPref,
-                AnimeUnityPlugin.PREF_LATEST_TITLE,
-                latestEpisodesSectionName,
-            )
-            "calendar" -> AnimeUnityPlugin.getConfiguredSectionTitle(
-                sharedPref,
-                AnimeUnityPlugin.PREF_CALENDAR_TITLE,
-                calendarSectionName,
-            )
-            "ongoing" -> AnimeUnityPlugin.getConfiguredSectionTitle(
-                sharedPref,
-                AnimeUnityPlugin.PREF_ONGOING_TITLE,
-                ongoingSectionName,
-            )
-            "popular" -> AnimeUnityPlugin.getConfiguredSectionTitle(
-                sharedPref,
-                AnimeUnityPlugin.PREF_POPULAR_TITLE,
-                popularSectionName,
-            )
-            "best" -> AnimeUnityPlugin.getConfiguredSectionTitle(
-                sharedPref,
-                AnimeUnityPlugin.PREF_BEST_TITLE,
-                bestSectionName,
-            )
-            "upcoming" -> AnimeUnityPlugin.getConfiguredSectionTitle(
-                sharedPref,
-                AnimeUnityPlugin.PREF_UPCOMING_TITLE,
-                upcomingSectionName,
-            )
-            "random" -> AnimeUnityPlugin.getConfiguredSectionTitle(
-                sharedPref,
-                AnimeUnityPlugin.PREF_RANDOM_TITLE,
-                randomSectionName,
-            )
-            else -> advancedSearchSectionName
-        }
+        if (sectionKey == AnimeUnitySections.ADVANCED) return advancedSearchSectionName
+
+        val config = homeSectionConfigByKey[sectionKey] ?: return advancedSearchSectionName
+        return AnimeUnityPlugin.getConfiguredSectionTitle(
+            sharedPref,
+            config.titlePrefKey,
+            config.defaultTitle,
+        )
     }
 
     private fun buildSectionNamesList(): List<MainPageData> {
         val order = AnimeUnityPlugin.getConfiguredSectionOrder(sharedPref)
         val sections = buildList {
             if (AnimeUnityPlugin.isAdvancedSearchEnabled(sharedPref)) {
-                add("advanced")
+                add(AnimeUnitySections.ADVANCED)
             }
             addAll(order.split(","))
         }
@@ -189,29 +394,19 @@ class AnimeUnity(
         return mainPageOf(
             *sections.mapNotNull { section ->
                 when (section) {
-                    "advanced" -> encodeMainPageSectionData("advanced", "$mainUrl/archivio/") to advancedSearchSectionName
-                    "latest" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_LATEST_EPISODES)) {
-                        encodeMainPageSectionData("latest", "$mainUrl/") to getSectionDisplayTitle("latest")
-                    } else null
-                    "calendar" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_CALENDAR)) {
-                        encodeMainPageSectionData("calendar", "$mainUrl/calendario") to getSectionDisplayTitle("calendar")
-                    } else null
-                    "ongoing" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_ONGOING)) {
-                        encodeMainPageSectionData("ongoing", "$mainUrl/archivio/") to getSectionDisplayTitle("ongoing")
-                    } else null
-                    "popular" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_POPULAR)) {
-                        encodeMainPageSectionData("popular", "$mainUrl/archivio/") to getSectionDisplayTitle("popular")
-                    } else null
-                    "best" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_BEST)) {
-                        encodeMainPageSectionData("best", "$mainUrl/archivio/") to getSectionDisplayTitle("best")
-                    } else null
-                    "upcoming" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_UPCOMING)) {
-                        encodeMainPageSectionData("upcoming", "$mainUrl/archivio/") to getSectionDisplayTitle("upcoming")
-                    } else null
-                    "random" -> if (isSectionEnabled(AnimeUnityPlugin.PREF_SHOW_RANDOM)) {
-                        encodeMainPageSectionData("random", "$mainUrl/archivio/") to getSectionDisplayTitle("random")
-                    } else null
-                    else -> null
+                    AnimeUnitySections.ADVANCED ->
+                        encodeMainPageSectionData(
+                            AnimeUnitySections.ADVANCED,
+                            "$mainUrl/archivio/",
+                        ) to advancedSearchSectionName
+                    else -> homeSectionConfigByKey[section]
+                        ?.takeIf { config -> isSectionEnabled(config.enabledPrefKey) }
+                        ?.let { config ->
+                            encodeMainPageSectionData(
+                                config.key,
+                                "$mainUrl/${config.path}",
+                            ) to getSectionDisplayTitle(config.key)
+                        }
                 }
             }.toTypedArray()
         )
@@ -222,25 +417,14 @@ class AnimeUnity(
     }
 
     private fun getSectionCount(sectionKey: String): Int {
-        val (key, defaultCount) = when (sectionKey) {
-            "advanced" -> AnimeUnityPlugin.PREF_ADVANCED_SEARCH_COUNT to
-                AnimeUnityPlugin.DEFAULT_ADVANCED_SEARCH_COUNT
-            "latest" -> AnimeUnityPlugin.PREF_LATEST_COUNT to
-                AnimeUnityPlugin.DEFAULT_SECTION_COUNT
-            "calendar" -> AnimeUnityPlugin.PREF_CALENDAR_COUNT to
-                AnimeUnityPlugin.DEFAULT_SECTION_COUNT
-            "ongoing" -> AnimeUnityPlugin.PREF_ONGOING_COUNT to
-                AnimeUnityPlugin.DEFAULT_SECTION_COUNT
-            "popular" -> AnimeUnityPlugin.PREF_POPULAR_COUNT to
-                AnimeUnityPlugin.DEFAULT_SECTION_COUNT
-            "best" -> AnimeUnityPlugin.PREF_BEST_COUNT to
-                AnimeUnityPlugin.DEFAULT_SECTION_COUNT
-            "upcoming" -> AnimeUnityPlugin.PREF_UPCOMING_COUNT to
-                AnimeUnityPlugin.DEFAULT_SECTION_COUNT
-            "random" -> AnimeUnityPlugin.PREF_RANDOM_COUNT to
-                AnimeUnityPlugin.DEFAULT_SECTION_COUNT
-            else -> return AnimeUnityPlugin.DEFAULT_SECTION_COUNT
+        val (key, defaultCount) = if (sectionKey == AnimeUnitySections.ADVANCED) {
+            AnimeUnityPlugin.PREF_ADVANCED_SEARCH_COUNT to AnimeUnityPlugin.DEFAULT_ADVANCED_SEARCH_COUNT
+        } else {
+            val config = homeSectionConfigByKey[sectionKey]
+                ?: return AnimeUnityPlugin.DEFAULT_SECTION_COUNT
+            config.countPrefKey to config.defaultCount
         }
+
         return (sharedPref?.getInt(key, defaultCount)
             ?: defaultCount).coerceIn(1, AnimeUnityPlugin.MAX_SECTION_COUNT)
     }
@@ -261,16 +445,344 @@ class AnimeUnity(
         return AnimeUnityPlugin.shouldUseUnifiedDubSubCards(sharedPref)
     }
 
+    private fun displayCacheKey(): String {
+        return listOf(
+            shouldShowScore(),
+            shouldShowDubSub(),
+            shouldShowEpisodeNumber(),
+            shouldUseUnifiedDubSubCards(),
+        ).joinToString(":")
+    }
+
+    private fun homeCacheKey(
+        sectionData: MainPageSectionData,
+        page: Int,
+        sectionTitle: String,
+    ): String {
+        val sectionRequestDataKey = if (sectionData.key in requestDataSectionKeys) {
+            getDataPerHomeSection(sectionData.key).toString()
+        } else {
+            ""
+        }
+        val dayKey = if (sectionData.key == AnimeUnitySections.CALENDAR) {
+            normalizeDayName(getCurrentItalianDayName())
+        } else {
+            ""
+        }
+
+        return listOf(
+            CACHE_SCHEMA,
+            "home",
+            mainUrl,
+            sectionData.key,
+            sectionData.baseUrl,
+            page,
+            sectionTitle,
+            getSectionCount(sectionData.key),
+            displayCacheKey(),
+            sectionRequestDataKey,
+            dayKey,
+        ).joinToString("|")
+    }
+
+    private fun animeUrlPathKey(url: String): String {
+        val animePath = url.substringAfter("/anime/", missingDelimiterValue = "")
+        return if (animePath.isNotBlank()) "/anime/${animePath.substringBefore('?')}" else url
+    }
+
+    private fun loadCacheKey(url: String): String {
+        return listOf(
+            CACHE_SCHEMA,
+            "load",
+            mainUrl,
+            animeUrlPathKey(url),
+            shouldUseUnifiedDubSubCards(),
+        ).joinToString("|")
+    }
+
+    private fun legacyLoadCacheKey(url: String): String {
+        return listOf(
+            CACHE_SCHEMA,
+            "load",
+            mainUrl,
+            animeUrlPathKey(url),
+            displayCacheKey(),
+        ).joinToString("|")
+    }
+
+    private fun loadCacheKeys(url: String): List<String> {
+        return listOf(loadCacheKey(url), legacyLoadCacheKey(url)).distinct()
+    }
+
+    private fun archiveBatchCacheKey(url: String, requestData: RequestData): String {
+        return listOf(CACHE_SCHEMA, "archive", mainUrl, url, requestData.toString()).joinToString("|")
+    }
+
+    private fun animePageDataCacheKey(url: String): String {
+        return listOf(CACHE_SCHEMA, "anime-page", mainUrl, animeUrlPathKey(url)).joinToString("|")
+    }
+
+    private fun sessionHeadersCacheKey(): String {
+        return listOf(CACHE_SCHEMA, "session-headers", mainUrl.toHttpUrl().host).joinToString("|")
+    }
+
+    private fun playerEmbedCacheKey(url: String): String {
+        return listOf(CACHE_SCHEMA, "player-embed", mainUrl, animeUrlPathKey(url)).joinToString("|")
+    }
+
+    private fun aniZipMetadataCacheKey(malId: Int?, anilistId: Int?): String {
+        return listOf(CACHE_SCHEMA, "anizip", "mal:${malId ?: ""}", "anilist:${anilistId ?: ""}")
+            .joinToString("|")
+    }
+
+    private fun trailerUrlCacheKey(anime: Anime): String {
+        return listOf(
+            CACHE_SCHEMA,
+            "trailer",
+            anime.id,
+            anime.malId ?: "",
+            anime.anilistId ?: "",
+            anime.title ?: "",
+            anime.titleEng ?: "",
+            anime.titleIt ?: "",
+        ).joinToString("|")
+    }
+
+    private fun getHomeCacheTtlMs(sectionKey: String): Long {
+        return when (sectionKey) {
+            AnimeUnitySections.LATEST -> LATEST_CACHE_TTL_MS
+            AnimeUnitySections.ONGOING,
+            AnimeUnitySections.POPULAR -> HOME_DYNAMIC_CACHE_TTL_MS
+            AnimeUnitySections.BEST,
+            AnimeUnitySections.UPCOMING -> HOME_STATIC_CACHE_TTL_MS
+            else -> HOME_DYNAMIC_CACHE_TTL_MS
+        }
+    }
+
+    private fun getHomeCacheExpirationMs(sectionKey: String): Long? {
+        if (sectionKey != AnimeUnitySections.CALENDAR) return null
+
+        val calendar = java.util.Calendar.getInstance(Locale.ITALY).apply {
+            add(java.util.Calendar.DAY_OF_YEAR, 1)
+            set(java.util.Calendar.HOUR_OF_DAY, 0)
+            set(java.util.Calendar.MINUTE, 0)
+            set(java.util.Calendar.SECOND, 0)
+            set(java.util.Calendar.MILLISECOND, 0)
+        }
+        return calendar.timeInMillis
+    }
+
+    private fun getHomeCachePriority(sectionKey: String): Int {
+        return when (sectionKey) {
+            AnimeUnitySections.ONGOING,
+            AnimeUnitySections.POPULAR,
+            AnimeUnitySections.BEST,
+            AnimeUnitySections.UPCOMING -> CACHE_PRIORITY_STANDARD
+            else -> CACHE_PRIORITY_VOLATILE
+        }
+    }
+
+    private fun getAnimeDetailTtlMs(anime: Anime): Long {
+        return if (getShowStatus(anime.status) == ShowStatus.Completed) {
+            DETAIL_COMPLETED_CACHE_TTL_MS
+        } else {
+            DETAIL_ONGOING_CACHE_TTL_MS
+        }
+    }
+
+    private fun shouldUseStaleWhileRevalidate(sectionKey: String): Boolean {
+        return sectionKey in staleWhileRevalidateSectionKeys
+    }
+
+    private fun ArchivePageResult.firstIdentity(): String? {
+        val anime = titles.firstOrNull() ?: return null
+        return "${anime.id}:${anime.slug}:${anime.episodesCount}:${anime.realEpisodesCount}:${anime.score}"
+    }
+
+    private fun List<LatestEpisodeItem>.firstIdentity(): String? {
+        val item = firstOrNull() ?: return null
+        return "${item.id}:${item.animeId}:${item.number}:${item.anime.score}"
+    }
+
+    private fun AnimeLoadCacheData.primaryAnime(): Anime {
+        return subPageData?.anime ?: dubPageData?.anime ?: currentPageData.anime
+    }
+
+    private fun AnimeLoadCacheData.totalEpisodeCount(): Int {
+        val subCount = subPageData?.episodes?.size ?: 0
+        val dubCount = dubPageData?.episodes?.size ?: 0
+        return maxOf(subCount, dubCount, currentPageData.episodes.size)
+    }
+
+    private fun buildAnimeLoadFingerprint(
+        primaryAnime: Anime,
+        subPageData: AnimePageData?,
+        dubPageData: AnimePageData?,
+        episodeMetadata: AniZipMetadata?,
+    ): String {
+        val subCount = subPageData?.episodes?.size ?: 0
+        val dubCount = dubPageData?.episodes?.size ?: 0
+        val metadataCount = episodeMetadata?.episodes?.size ?: 0
+        return listOf(
+            primaryAnime.id,
+            primaryAnime.status,
+            primaryAnime.score ?: "",
+            primaryAnime.realEpisodesCount ?: "",
+            primaryAnime.episodesCount,
+            subCount,
+            dubCount,
+            metadataCount,
+        ).joinToString(":")
+    }
+
+    private inline fun <reified T> readDiskCache(key: String, allowExpired: Boolean = false): T? {
+        val payload = AnimeUnityCache.read(key, allowExpired)?.payload ?: return null
+        return runCatching { parseJson<T>(payload) }.getOrNull()
+            ?: run {
+                AnimeUnityCache.remove(key)
+                null
+            }
+    }
+
+    private inline fun <reified T> readDiskCacheRecord(
+        key: String,
+        allowExpired: Boolean = false,
+    ): Pair<T, AnimeUnityCache.CacheRecord>? {
+        val record = AnimeUnityCache.read(key, allowExpired) ?: return null
+        val value = runCatching { parseJson<T>(record.payload) }.getOrNull()
+            ?: run {
+                AnimeUnityCache.remove(key)
+                return null
+            }
+        return value to record
+    }
+
+    private fun readDiskTextCache(key: String, allowExpired: Boolean = false): String? {
+        return AnimeUnityCache.read(key, allowExpired)?.payload
+    }
+
+    private fun writeDiskCache(
+        key: String,
+        namespace: String,
+        payload: Any,
+        ttlMs: Long,
+        expiresAtMs: Long? = null,
+        priority: Int = 0,
+        pinned: Boolean = false,
+    ) {
+        AnimeUnityCache.write(
+            key = key,
+            namespace = namespace,
+            payload = payload.toJson(),
+            ttlMs = ttlMs,
+            expiresAtMs = expiresAtMs,
+            priority = priority,
+            pinned = pinned,
+        )
+    }
+
+    private fun writeDiskTextCache(
+        key: String,
+        namespace: String,
+        payload: String,
+        ttlMs: Long,
+        expiresAtMs: Long? = null,
+        priority: Int = 0,
+        pinned: Boolean = false,
+    ) {
+        AnimeUnityCache.write(
+            key = key,
+            namespace = namespace,
+            payload = payload,
+            ttlMs = ttlMs,
+            expiresAtMs = expiresAtMs,
+            priority = priority,
+            pinned = pinned,
+        )
+    }
+
+    private inline fun <T> runCatchingCancellable(block: () -> T): Result<T> {
+        return try {
+            Result.success(block())
+        } catch (throwable: Throwable) {
+            if (throwable is CancellationException) throw throwable
+            Result.failure(throwable)
+        }
+    }
+
+    private suspend fun <A, B> Iterable<A>.safeAmap(
+        concurrency: Int = 5,
+        transform: suspend (A) -> B?,
+    ): List<B> = supervisorScope {
+        val semaphore = Semaphore(concurrency.coerceAtLeast(1))
+        map { item ->
+            async<B?>(Dispatchers.IO) {
+                var acquiredPermit = false
+                try {
+                    semaphore.acquire()
+                    acquiredPermit = true
+                    transform(item)
+                } catch (throwable: Throwable) {
+                    if (throwable is CancellationException) throw throwable
+                    null
+                } finally {
+                    if (acquiredPermit) semaphore.release()
+                }
+            }
+        }.awaitAll().filterNotNull()
+    }
+
+    private suspend fun runLimitedAsync(
+        concurrency: Int = 7,
+        vararg tasks: suspend () -> Unit,
+    ) = supervisorScope {
+        val semaphore = Semaphore(concurrency.coerceAtLeast(1))
+        tasks.map { task ->
+            async(Dispatchers.IO) {
+                var acquiredPermit = false
+                try {
+                    semaphore.acquire()
+                    acquiredPermit = true
+                    task()
+                } catch (throwable: Throwable) {
+                    if (throwable is CancellationException) throw throwable
+                } finally {
+                    if (acquiredPermit) semaphore.release()
+                }
+            }
+        }.awaitAll()
+    }
+
+    @OptIn(DelicateCoroutinesApi::class)
+    private fun revalidateInBackground(
+        key: String,
+        block: suspend () -> Unit,
+    ) {
+        synchronized(revalidatingKeys) {
+            if (!revalidatingKeys.add(key)) return
+        }
+
+        GlobalScope.launch(Dispatchers.IO) {
+            try {
+                block()
+            } finally {
+                synchronized(revalidatingKeys) {
+                    revalidatingKeys.remove(key)
+                }
+            }
+        }
+    }
+
     private fun withoutDubSuffix(title: String): String {
         return title.replace(" (ITA)", "")
     }
 
     private fun getAnimeTitle(anime: Anime): String {
-        return anime.titleIt ?: anime.titleEng ?: anime.title!!
+        return anime.titleIt ?: anime.titleEng ?: anime.title ?: anime.slug
     }
 
     private fun getAnimeTitle(anime: LatestEpisodeAnime): String {
-        return anime.titleIt ?: anime.titleEng ?: anime.title!!
+        return anime.titleIt ?: anime.titleEng ?: anime.title ?: anime.slug
     }
 
     private fun isDubAnime(anime: Anime): Boolean {
@@ -279,6 +791,88 @@ class AnimeUnity(
 
     private fun isDubAnime(anime: LatestEpisodeAnime): Boolean {
         return anime.dub == 1 || getAnimeTitle(anime).contains("(ITA)")
+    }
+
+    private fun positiveEpisodeCount(count: Int?): Int? {
+        return count?.takeIf { it > 0 }
+    }
+
+    private fun getEpisodeCount(anime: Anime): Int? {
+        return positiveEpisodeCount(anime.realEpisodesCount)
+            ?: positiveEpisodeCount(anime.episodesCount)
+    }
+
+    private fun getEpisodeCount(anime: LatestEpisodeAnime): Int? {
+        return positiveEpisodeCount(anime.realEpisodesCount)
+            ?: positiveEpisodeCount(anime.episodesCount)
+    }
+
+    private fun buildAnimeBadgeState(anime: Anime): EpisodeBadgeState {
+        val episodeCount = getEpisodeCount(anime)
+        return if (isDubAnime(anime)) {
+            EpisodeBadgeState(hasSub = false, hasDub = true, dubEpisodeCount = episodeCount)
+        } else {
+            EpisodeBadgeState(hasSub = true, hasDub = false, subEpisodeCount = episodeCount)
+        }
+    }
+
+    private fun buildLatestEpisodeBadgeState(item: LatestEpisodeItem): EpisodeBadgeState {
+        val episodeNumber = positiveEpisodeCount(item.number.toIntOrNull())
+        return if (isDubAnime(item.anime)) {
+            EpisodeBadgeState(hasSub = false, hasDub = true, dubEpisodeCount = episodeNumber)
+        } else {
+            EpisodeBadgeState(hasSub = true, hasDub = false, subEpisodeCount = episodeNumber)
+        }
+    }
+
+    private fun getFirstAvailableScore(items: List<LatestEpisodeItem>): String? {
+        return items.firstNotNullOfOrNull { item ->
+            item.anime.score?.trim()?.takeIf(String::isNotBlank)
+        }
+    }
+
+    private fun combineAnimeBadgeStates(animes: List<Anime>): EpisodeBadgeState {
+        val subEpisodeCount = animes
+            .filterNot(::isDubAnime)
+            .mapNotNull(::getEpisodeCount)
+            .maxOrNull()
+        val dubEpisodeCount = animes
+            .filter(::isDubAnime)
+            .mapNotNull(::getEpisodeCount)
+            .maxOrNull()
+
+        return EpisodeBadgeState(
+            hasSub = animes.any { !isDubAnime(it) },
+            hasDub = animes.any(::isDubAnime),
+            subEpisodeCount = subEpisodeCount,
+            dubEpisodeCount = dubEpisodeCount,
+        )
+    }
+
+    private fun combineCalendarBadgeStates(items: List<CalendarAnimeItem>): EpisodeBadgeState {
+        val subEpisodeNumber = items
+            .filterNot { isDubAnime(it.anime) }
+            .mapNotNull { positiveEpisodeCount(it.episodeNumber) }
+            .maxOrNull()
+        val dubEpisodeNumber = items
+            .filter { isDubAnime(it.anime) }
+            .mapNotNull { positiveEpisodeCount(it.episodeNumber) }
+            .maxOrNull()
+
+        return EpisodeBadgeState(
+            hasSub = items.any { !isDubAnime(it.anime) },
+            hasDub = items.any { isDubAnime(it.anime) },
+            subEpisodeCount = subEpisodeNumber,
+            dubEpisodeCount = dubEpisodeNumber,
+        )
+    }
+
+    private fun EpisodeBadgeState.withEpisodeNumber(episodeNumber: Int?): EpisodeBadgeState {
+        val normalizedEpisodeNumber = positiveEpisodeCount(episodeNumber) ?: return this
+        return copy(
+            subEpisodeCount = if (hasSub) normalizedEpisodeNumber else null,
+            dubEpisodeCount = if (hasDub) normalizedEpisodeNumber else null,
+        )
     }
 
     private fun Anime.contentKey(): String {
@@ -307,7 +901,7 @@ class AnimeUnity(
         return when {
             primaryIsDub && !candidateIsDub -> candidate
             !primaryIsDub && candidateIsDub -> primary
-            candidate.episodesCount > primary.episodesCount -> candidate
+            (getEpisodeCount(candidate) ?: 0) > (getEpisodeCount(primary) ?: 0) -> candidate
             else -> primary
         }
     }
@@ -319,7 +913,7 @@ class AnimeUnity(
         return when {
             primaryIsDub && !candidateIsDub -> candidate
             !primaryIsDub && candidateIsDub -> primary
-            candidate.episodesCount > primary.episodesCount -> candidate
+            (getEpisodeCount(candidate) ?: 0) > (getEpisodeCount(primary) ?: 0) -> candidate
             else -> primary
         }
     }
@@ -330,7 +924,7 @@ class AnimeUnity(
             return animes.map { anime ->
                 GroupedAnimeCard(
                     anime = anime,
-                    hasDub = isDubAnime(anime),
+                    badges = buildAnimeBadgeState(anime),
                 )
             }
         }
@@ -341,7 +935,38 @@ class AnimeUnity(
             .map { variants ->
                 GroupedAnimeCard(
                     anime = variants.reduce { primary, candidate -> preferAnime(primary, candidate) },
-                    hasDub = variants.any { isDubAnime(it) },
+                    badges = combineAnimeBadgeStates(variants),
+                )
+            }
+    }
+
+    private fun groupCalendarAnimeCards(items: List<CalendarAnimeItem>): List<GroupedCalendarAnimeCard> {
+        if (items.isEmpty()) return emptyList()
+        if (!shouldUseUnifiedDubSubCards()) {
+            return items.map { item ->
+                GroupedCalendarAnimeCard(
+                    anime = item.anime,
+                    badges = buildAnimeBadgeState(item.anime).withEpisodeNumber(item.episodeNumber),
+                    episodeNumber = item.episodeNumber,
+                )
+            }
+        }
+
+        return items
+            .groupBy { it.anime.contentKey() }
+            .values
+            .map { variants ->
+                val latestEpisode = variants.maxWithOrNull(
+                    compareBy<CalendarAnimeItem>(
+                        { it.episodeNumber ?: Int.MIN_VALUE },
+                        { getAnimeTitle(it.anime) }
+                    )
+                ) ?: variants.first()
+
+                GroupedCalendarAnimeCard(
+                    anime = variants.map { it.anime }.reduce { primary, candidate -> preferAnime(primary, candidate) },
+                    badges = combineCalendarBadgeStates(variants),
+                    episodeNumber = latestEpisode.episodeNumber,
                 )
             }
     }
@@ -352,8 +977,9 @@ class AnimeUnity(
             return items.map { item ->
                 GroupedLatestEpisodeCard(
                     anime = item.anime,
-                    hasDub = isDubAnime(item.anime),
+                    badges = buildLatestEpisodeBadgeState(item),
                     episodeNumber = item.number,
+                    score = item.anime.score,
                 )
             }
         }
@@ -362,17 +988,14 @@ class AnimeUnity(
             .groupBy { it.anime.contentKey() }
             .values
             .map { variants ->
-                val latestEpisode = variants.maxWithOrNull(
-                    compareBy<LatestEpisodeItem>(
-                        { parseEpisodeSortValue(it.number) ?: Double.NEGATIVE_INFINITY },
-                        { it.number }
-                    )
-                ) ?: variants.first()
+                val latestEpisode = variants.first()
 
                 GroupedLatestEpisodeCard(
-                    anime = variants.map { it.anime }.reduce { primary, candidate -> preferAnime(primary, candidate) },
-                    hasDub = variants.any { isDubAnime(it.anime) },
+                    anime = latestEpisode.anime,
+                    badges = buildLatestEpisodeBadgeState(latestEpisode),
                     episodeNumber = latestEpisode.number,
+                    score = latestEpisode.anime.score?.takeIf(String::isNotBlank)
+                        ?: getFirstAvailableScore(variants),
                 )
             }
     }
@@ -401,22 +1024,27 @@ class AnimeUnity(
         }
     }
 
-    private fun getMiniCardDubStatus(hasDub: Boolean): DubStatus {
-        return if (hasDub) DubStatus.Dubbed else DubStatus.Subbed
-    }
-
     private fun applyCardDisplayState(
         response: AnimeSearchResponse,
-        dubStatus: DubStatus,
+        badges: EpisodeBadgeState,
         poster: String?,
         score: String?,
-        episodeNumber: Int? = null,
     ) {
         if (shouldShowDubSub()) {
             if (shouldShowEpisodeNumber()) {
-                response.addDubStatus(dubStatus, episodeNumber)
+                if (badges.hasSub) {
+                    badges.subEpisodeCount?.let(response::addSub) ?: response.addDubStatus(DubStatus.Subbed)
+                }
+                if (badges.hasDub) {
+                    badges.dubEpisodeCount?.let(response::addDub) ?: response.addDubStatus(DubStatus.Dubbed)
+                }
             } else {
-                response.addDubStatus(dubStatus)
+                if (badges.hasSub) {
+                    response.addDubStatus(DubStatus.Subbed)
+                }
+                if (badges.hasDub) {
+                    response.addDubStatus(DubStatus.Dubbed)
+                }
             }
         }
 
@@ -442,7 +1070,25 @@ class AnimeUnity(
         }
     }
 
-    private suspend fun setupHeadersAndCookies() {
+    private suspend fun setupHeadersAndCookies(forceNetwork: Boolean = false) {
+        val currentHost = mainUrl.toHttpUrl().host
+        val cacheKey = sessionHeadersCacheKey()
+        if (!forceNetwork) {
+            readDiskCache<SessionHeadersCacheData>(cacheKey)?.let { cachedSession ->
+                val cachedHeaders = cachedSession.headers
+                val isFresh = System.currentTimeMillis() - cachedSession.savedAtMs < SESSION_HEADERS_CACHE_TTL_MS
+                val isForCurrentHost = cachedHeaders["Host"] == currentHost &&
+                    cachedHeaders["Referer"] == mainUrl
+                val hasSessionData = cachedHeaders["Cookie"].orEmpty().isNotBlank() &&
+                    cachedHeaders["X-CSRF-Token"].orEmpty().isNotBlank()
+
+                if (isFresh && isForCurrentHost && hasSessionData) {
+                    headers.putAll(cachedHeaders)
+                    return
+                }
+            }
+        }
+
         val response = app.get("$mainUrl/archivio", headers = headers)
 
         val csrfToken = response.document.head().select("meta[name=csrf-token]").attr("content")
@@ -456,6 +1102,16 @@ class AnimeUnity(
             "Cookie" to cookies
         )
         headers.putAll(h)
+        writeDiskCache(
+            key = cacheKey,
+            namespace = AnimeUnityCache.NAMESPACE_EXTERNAL,
+            payload = SessionHeadersCacheData(
+                headers = headers.toMap(),
+                savedAtMs = System.currentTimeMillis(),
+            ),
+            ttlMs = SESSION_HEADERS_CACHE_TTL_MS,
+            priority = CACHE_PRIORITY_IMPORTANT,
+        )
     }
 
     private fun resetHeadersAndCookies() {
@@ -467,11 +1123,20 @@ class AnimeUnity(
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0"
     }
 
-    private suspend fun searchResponseBuilder(objectList: List<Anime>, episodeNumber: Int? = null): List<SearchResponse> {
-        return groupAnimeCards(objectList).amap { entry ->
+    private suspend fun searchResponseBuilder(
+        objectList: List<Anime>,
+        episodeNumber: Int? = null,
+        limit: Int? = null,
+    ): List<SearchResponse> {
+        val groupedCards = groupAnimeCards(objectList).let { cards ->
+            limit?.let(cards::take) ?: cards
+        }
+
+        return groupedCards.safeAmap(concurrency = 6) { entry ->
             val anime = entry.anime
             val title = getAnimeTitle(anime)
-            val poster = getImage(anime.imageUrl, anime.anilistId)
+            val poster = runCatchingCancellable { getImage(anime.imageUrl, anime.anilistId) }.getOrNull()
+            val badges = entry.badges.withEpisodeNumber(episodeNumber)
 
             newAnimeSearchResponse(
                 name = buildDisplayTitle(title, episodeNumber),
@@ -484,18 +1149,33 @@ class AnimeUnity(
             ).apply {
                 applyCardDisplayState(
                     response = this,
-                    dubStatus = getMiniCardDubStatus(entry.hasDub),
+                    badges = badges,
                     poster = poster,
-                    score = anime.score,
-                    episodeNumber = episodeNumber
+                    score = anime.score
                 )
             }
         }
     }
 
     private suspend fun fetchArchiveBatch(url: String, requestData: RequestData): ApiResponse {
+        val cacheKey = archiveBatchCacheKey(url, requestData)
+        archiveBatchCache.get(cacheKey)?.let { return it }
+        readDiskCache<ApiResponse>(cacheKey)?.let { cachedResponse ->
+            archiveBatchCache.put(cacheKey, cachedResponse)
+            return cachedResponse
+        }
+
         val response = app.post(url, headers = headers, requestBody = requestData.toRequestBody())
-        return parseJson<ApiResponse>(response.text)
+        val parsedResponse = parseJson<ApiResponse>(response.text)
+        archiveBatchCache.put(cacheKey, parsedResponse)
+        writeDiskCache(
+            key = cacheKey,
+            namespace = AnimeUnityCache.NAMESPACE_ARCHIVE,
+            payload = parsedResponse,
+            ttlMs = HOME_DYNAMIC_CACHE_TTL_MS,
+            priority = CACHE_PRIORITY_STANDARD,
+        )
+        return parsedResponse
     }
 
     private suspend fun fetchArchiveSectionPage(
@@ -531,51 +1211,70 @@ class AnimeUnity(
         )
     }
 
-    private suspend fun fetchRandomTitles(url: String, sectionCount: Int): Pair<List<Anime>, Int> {
+    private suspend fun fetchRandomTitles(
+        url: String,
+        sectionCount: Int,
+        excludedIds: Set<Int> = emptySet(),
+    ): Pair<List<Anime>, Int> {
         val requestData = RequestData(dubbed = 0)
         val initialResponse = fetchArchiveBatch(url, requestData.copy(offset = 0))
         val total = initialResponse.total
         val collectedTitles = linkedMapOf<Int, Anime>()
         val requestedOffsets = mutableSetOf<Int>()
-        val maxAttempts = ((sectionCount + ARCHIVE_BATCH_SIZE - 1) / ARCHIVE_BATCH_SIZE) * 3
 
         fun collectBatch(batch: List<Anime>) {
-            batch.forEach { anime ->
+            batch.filterNot { it.id in excludedIds }.forEach { anime ->
                 collectedTitles.putIfAbsent(anime.id, anime)
             }
         }
 
+        if (total <= 0) return emptyList<Anime>() to 0
+
         if (total <= ARCHIVE_BATCH_SIZE) {
             collectBatch(initialResponse.titles.orEmpty())
-            return collectedTitles.values.shuffled().take(sectionCount) to total
+            return collectedTitles.values.shuffled() to total
         }
 
-        repeat(maxAttempts) {
-            if (collectedTitles.size >= sectionCount) {
-                return@repeat
-            }
+        val maxRequests = when {
+            sectionCount <= 10 -> 2
+            sectionCount <= 20 -> 3
+            else -> 4
+        }
+
+        repeat(maxRequests) {
+            if (collectedTitles.size >= sectionCount * 2) return@repeat
 
             val maxOffset = (total - ARCHIVE_BATCH_SIZE).coerceAtLeast(0)
             val randomOffset = if (maxOffset == 0) 0 else (0..maxOffset).random()
-            if (!requestedOffsets.add(randomOffset)) {
-                return@repeat
+            
+            if (requestedOffsets.add(randomOffset)) {
+                try {
+                    val batch = fetchArchiveBatch(url, requestData.copy(offset = randomOffset)).titles
+                    if (!batch.isNullOrEmpty()) {
+                        collectBatch(batch)
+                    }
+                } catch (exception: Exception) {
+                    if (exception is CancellationException) throw exception
+                }
             }
-
-            collectBatch(fetchArchiveBatch(url, requestData.copy(offset = randomOffset)).titles.orEmpty())
         }
 
-        if (collectedTitles.isEmpty()) {
+        if (collectedTitles.size < sectionCount) {
             collectBatch(initialResponse.titles.orEmpty())
         }
 
-        return collectedTitles.values.shuffled().take(sectionCount) to total
+        val result = collectedTitles.values.toList().shuffled()
+        return result to total
     }
 
-    private suspend fun latestEpisodesResponseBuilder(objectList: List<LatestEpisodeItem>): List<SearchResponse> {
-        return groupLatestEpisodeCards(objectList).amap { entry ->
+    private suspend fun latestEpisodesResponseBuilder(
+        objectList: List<LatestEpisodeItem>,
+        limit: Int,
+    ): List<SearchResponse> {
+        return groupLatestEpisodeCards(objectList).take(limit).safeAmap(concurrency = 6) { entry ->
             val anime = entry.anime
             val title = getAnimeTitle(anime)
-            val poster = getImage(anime.imageUrl, anime.anilistId)
+            val poster = runCatchingCancellable { getImage(anime.imageUrl, anime.anilistId) }.getOrNull()
 
             newAnimeSearchResponse(
                 name = buildDisplayTitle(title, entry.episodeNumber.toIntOrNull()),
@@ -588,10 +1287,37 @@ class AnimeUnity(
             ).apply {
                 applyCardDisplayState(
                     response = this,
-                    dubStatus = getMiniCardDubStatus(entry.hasDub),
+                    badges = entry.badges,
+                    poster = poster,
+                    score = entry.score
+                )
+            }
+        }
+    }
+
+    private suspend fun calendarResponseBuilder(
+        items: List<CalendarAnimeItem>,
+        limit: Int,
+    ): List<SearchResponse> {
+        return groupCalendarAnimeCards(items).take(limit).safeAmap(concurrency = 6) { entry ->
+            val anime = entry.anime
+            val title = getAnimeTitle(anime)
+            val poster = runCatchingCancellable { getImage(anime.imageUrl, anime.anilistId) }.getOrNull()
+
+            newAnimeSearchResponse(
+                name = buildDisplayTitle(title, entry.episodeNumber),
+                url = "$mainUrl/anime/${anime.id}-${anime.slug}",
+                type = when {
+                    anime.type == "TV" -> TvType.Anime
+                    anime.type == "Movie" || anime.episodesCount == 1 -> TvType.AnimeMovie
+                    else -> TvType.OVA
+                }
+            ).apply {
+                applyCardDisplayState(
+                    response = this,
+                    badges = entry.badges,
                     poster = poster,
                     score = anime.score,
-                    episodeNumber = entry.episodeNumber.toIntOrNull()
                 )
             }
         }
@@ -609,10 +1335,10 @@ class AnimeUnity(
 
     private suspend fun getImage(imageUrl: String?, anilistId: Int?): String? {
         if (!imageUrl.isNullOrEmpty()) {
-            try {
-                val fileName = imageUrl.substringAfterLast("/")
+            val fileName = imageUrl.substringAfterLast("/")
+            if (fileName.isNotBlank()) {
                 return "https://${getImageCdnHost()}/anime/$fileName"
-            } catch (_: Exception) {}
+            }
         }
         return anilistId?.let { getAnilistPoster(it) }
     }
@@ -634,6 +1360,119 @@ class AnimeUnity(
 
     private fun buildEpisodeDisplayName(number: String): String {
         return "Episodio $number"
+    }
+
+    private fun normalizeEpisodeNumber(number: String?): String? {
+        val normalized = number
+            ?.trim()
+            ?.replace(',', '.')
+            ?.takeIf(String::isNotBlank)
+            ?: return null
+        val numericValue = normalized.toDoubleOrNull() ?: return normalized
+        val intValue = numericValue.toInt()
+
+        return if (numericValue == intValue.toDouble()) intValue.toString() else numericValue.toString()
+    }
+
+    private fun buildEpisodeMetadataIndex(metadata: AniZipMetadata?): EpisodeMetadataIndex {
+        val exactEpisodes = linkedMapOf<String, AniZipEpisode>()
+        val normalizedEpisodes = linkedMapOf<String, AniZipEpisode>()
+
+        metadata?.episodes.orEmpty().forEach { (key, episode) ->
+            key.takeIf(String::isNotBlank)?.let { exactEpisodes.putIfAbsent(it, episode) }
+            normalizeEpisodeNumber(key)?.let { normalizedEpisodes.putIfAbsent(it, episode) }
+
+            val episodeNumber = episode.episode?.trim()?.takeIf(String::isNotBlank)
+            episodeNumber?.let { exactEpisodes.putIfAbsent(it, episode) }
+            episodeNumber?.let(::normalizeEpisodeNumber)?.let {
+                normalizedEpisodes.putIfAbsent(it, episode)
+            }
+        }
+
+        return EpisodeMetadataIndex(
+            byExactNumber = exactEpisodes,
+            byNormalizedNumber = normalizedEpisodes,
+        )
+    }
+
+    private fun getAniZipEpisode(metadataIndex: EpisodeMetadataIndex, number: String): AniZipEpisode? {
+        return metadataIndex.byExactNumber[number]
+            ?: normalizeEpisodeNumber(number)?.let(metadataIndex.byNormalizedNumber::get)
+    }
+
+    private fun getAniZipEpisodeTitle(metadata: AniZipEpisode?): String? {
+        val titles = metadata?.title ?: return null
+
+        return listOf("it", "en", "x-jat", "ja")
+            .firstNotNullOfOrNull { language -> titles[language]?.trim()?.takeIf(String::isNotBlank) }
+            ?: titles.values.firstNotNullOfOrNull { it?.trim()?.takeIf(String::isNotBlank) }
+    }
+
+    private fun cleanExternalEpisodeText(text: String?): String? {
+        return text
+            ?.replace("<[^>]+>".toRegex(), " ")
+            ?.replace("\\s+".toRegex(), " ")
+            ?.trim()
+            ?.takeIf(String::isNotBlank)
+    }
+
+    private fun getAniZipEpisodeDescription(metadata: AniZipEpisode?): String {
+        return cleanExternalEpisodeText(metadata?.overview)
+            ?: cleanExternalEpisodeText(metadata?.summary)
+            ?: noEpisodeDescription
+    }
+
+    private fun getAniZipEpisodeAirDate(metadata: AniZipEpisode?): String? {
+        return metadata?.airDateUtc
+            ?.substringBefore("T")
+            ?.takeIf(String::isNotBlank)
+            ?: metadata?.airDate?.takeIf(String::isNotBlank)
+    }
+
+    private suspend fun fetchAniZipMetadata(malId: Int?, anilistId: Int?): AniZipMetadata? {
+        val cacheKey = aniZipMetadataCacheKey(malId, anilistId)
+        aniZipMetadataCache.get(cacheKey)?.let { return it }
+        readDiskCache<AniZipMetadata>(cacheKey)?.let { cachedMetadata ->
+            aniZipMetadataCache.put(cacheKey, cachedMetadata)
+            return cachedMetadata
+        }
+
+        val identifiers = buildList {
+            malId?.let { add("mal_id" to it) }
+            anilistId?.let { add("anilist_id" to it) }
+        }
+
+        identifiers.forEach { (parameter, id) ->
+            val url = "https://api.ani.zip/mappings".toHttpUrl().newBuilder()
+                .addQueryParameter(parameter, id.toString())
+                .build()
+                .toString()
+            val response = runCatchingCancellable { app.get(url).text }.getOrNull() ?: return@forEach
+            val metadata = runCatching { parseJson<AniZipMetadata>(response) }.getOrNull()
+
+            metadata?.let { resolvedMetadata ->
+                if (
+                    resolvedMetadata.episodes?.isNotEmpty() == true ||
+                    resolvedMetadata.mappings?.hasSyncIds() == true
+                ) {
+                    aniZipMetadataCache.put(cacheKey, resolvedMetadata)
+                    writeDiskCache(
+                        key = cacheKey,
+                        namespace = AnimeUnityCache.NAMESPACE_EXTERNAL,
+                        payload = resolvedMetadata,
+                        ttlMs = EXTERNAL_CACHE_TTL_MS,
+                        priority = CACHE_PRIORITY_STANDARD,
+                    )
+                    return resolvedMetadata
+                }
+            }
+        }
+
+        return null
+    }
+
+    private fun AniZipMappings.hasSyncIds(): Boolean {
+        return malId != null || anilistId != null || kitsuId != null
     }
 
     private fun buildPlayerSourceOptions(playbackData: EpisodePlaybackData): List<PlayerSourceOption> {
@@ -666,42 +1505,70 @@ class AnimeUnity(
         return orderedSources
     }
 
+    private suspend fun getPlayerEmbedUrl(playerUrl: String): String? {
+        val cacheKey = playerEmbedCacheKey(playerUrl)
+        playerEmbedUrlCache.get(cacheKey)?.let { return it }
+        readDiskTextCache(cacheKey)?.let { cachedEmbedUrl ->
+            playerEmbedUrlCache.put(cacheKey, cachedEmbedUrl)
+            return cachedEmbedUrl
+        }
+
+        val embedUrl = runCatchingCancellable {
+            app.get(playerUrl).document
+                .select("video-player")
+                .attr("embed_url")
+                .takeIf(String::isNotBlank)
+        }.getOrNull()
+
+        if (embedUrl != null) {
+            playerEmbedUrlCache.put(cacheKey, embedUrl)
+            writeDiskTextCache(
+                key = cacheKey,
+                namespace = AnimeUnityCache.NAMESPACE_EXTERNAL,
+                payload = embedUrl,
+                ttlMs = PLAYER_EMBED_CACHE_TTL_MS,
+                priority = CACHE_PRIORITY_STANDARD,
+            )
+        }
+
+        return embedUrl
+    }
+
     private fun buildEpisodeSourceMap(anime: Anime?, episodes: List<Episode>): LinkedHashMap<String, EpisodeSource> {
         val sourceAnime = anime ?: return linkedMapOf()
         val sourceMap = linkedMapOf<String, EpisodeSource>()
 
         episodes.forEach { episode ->
             val rawNumber = episode.number.trim()
-            sourceMap.putIfAbsent(
-                rawNumber,
-                EpisodeSource(
+            if (!sourceMap.containsKey(rawNumber)) {
+                sourceMap[rawNumber] = EpisodeSource(
                     number = rawNumber,
                     url = getEpisodeUrl(sourceAnime, episode),
                 )
-            )
+            }
         }
 
         return sourceMap
     }
 
-    private fun buildMergedEpisodes(
-        primaryEpisodes: LinkedHashMap<String, EpisodeSource>,
-        fallbackEpisodes: LinkedHashMap<String, EpisodeSource>,
+    private fun buildEpisodes(
+        episodes: LinkedHashMap<String, EpisodeSource>,
         subEpisodes: LinkedHashMap<String, EpisodeSource>,
         dubEpisodes: LinkedHashMap<String, EpisodeSource>,
-        fallbackNamePrefix: String? = null,
+        episodeMetadataIndex: EpisodeMetadataIndex,
+        episodeFallbackPosterUrl: String?,
     ): List<com.lagradost.cloudstream3.Episode> {
-        return (primaryEpisodes.keys + fallbackEpisodes.keys)
-            .distinct()
+        return episodes.keys
             .sortedWith(
                 compareBy<String>(
                     { parseEpisodeSortValue(it) ?: Double.POSITIVE_INFINITY },
                     { it }
                 )
             )
-            .map { episodeNumber ->
-                val source = primaryEpisodes[episodeNumber] ?: fallbackEpisodes[episodeNumber]!!
-                val isFallbackEpisode = primaryEpisodes[episodeNumber] == null
+            .mapNotNull { episodeNumber ->
+                val source = episodes[episodeNumber] ?: return@mapNotNull null
+                val metadata = getAniZipEpisode(episodeMetadataIndex, source.number)
+                val episodeName = getAniZipEpisodeTitle(metadata) ?: buildEpisodeDisplayName(source.number)
                 val playbackData = EpisodePlaybackData(
                     preferredUrl = source.url,
                     subUrl = subEpisodes[episodeNumber]?.url,
@@ -709,11 +1576,14 @@ class AnimeUnity(
                 )
                 newEpisode(playbackData) {
                     this.episode = source.number.toIntOrNull()
-                    if (isFallbackEpisode && fallbackNamePrefix != null) {
-                        this.name = "$fallbackNamePrefix${buildEpisodeDisplayName(source.number)}"
-                    } else if (this.episode == null) {
-                        this.name = buildEpisodeDisplayName(source.number)
-                    }
+                    this.name = episodeName
+                    metadata?.rating
+                        ?.takeIf(String::isNotBlank)
+                        ?.let { this.score = Score.from(it, 10) }
+                    this.posterUrl = metadata?.image?.takeIf(String::isNotBlank) ?: episodeFallbackPosterUrl
+                    this.description = getAniZipEpisodeDescription(metadata)
+                    getAniZipEpisodeAirDate(metadata)?.let { this.addDate(it) }
+                    this.runTime = metadata?.runtime
                 }
             }
     }
@@ -737,9 +1607,28 @@ class AnimeUnity(
         )
     }
 
-    private suspend fun fetchAnimePageData(url: String): AnimePageData {
+    private suspend fun fetchAnimePageData(url: String, forceRefresh: Boolean = false): AnimePageData {
+        val cacheKey = animePageDataCacheKey(url)
+        if (!forceRefresh) {
+            animePageDataCache.get(cacheKey)?.let { return it }
+            readDiskCache<AnimePageData>(cacheKey)?.let { cachedPageData ->
+                animePageDataCache.put(cacheKey, cachedPageData)
+                return cachedPageData
+            }
+        }
+
         val animePage = app.get(url).document
-        return parseAnimePageData(animePage)
+        val pageData = parseAnimePageData(animePage)
+        animePageDataCache.put(cacheKey, pageData)
+        writeDiskCache(
+            key = cacheKey,
+            namespace = AnimeUnityCache.NAMESPACE_ANIME_PAGE,
+            payload = pageData,
+            ttlMs = getAnimeDetailTtlMs(pageData.anime),
+            priority = CACHE_PRIORITY_IMPORTANT,
+            pinned = true,
+        )
+        return pageData
     }
 
     private suspend fun getAllEpisodes(
@@ -777,6 +1666,13 @@ class AnimeUnity(
     }
 
     private suspend fun getAnilistPoster(anilistId: Int): String {
+        anilistPosterCache.get(anilistId)?.let { return it }
+        val cacheKey = listOf(CACHE_SCHEMA, "anilist-poster", anilistId).joinToString("|")
+        readDiskTextCache(cacheKey)?.let { cachedPoster ->
+            anilistPosterCache.put(anilistId, cachedPoster)
+            return cachedPoster
+        }
+
         val query = """
         query (${'$'}id: Int) {
             Media(id: ${'$'}id, type: ANIME) {
@@ -792,14 +1688,41 @@ class AnimeUnity(
         val response = app.post("https://graphql.anilist.co", data = body)
         val anilistObj = parseJson<AnilistResponse>(response.text)
 
-        return anilistObj.data.media.coverImage?.let { coverImage ->
-            coverImage.large ?: coverImage.medium!!
+        val poster = anilistObj.data.media.coverImage?.let { coverImage ->
+            coverImage.extraLarge ?: coverImage.large ?: coverImage.medium
         } ?: throw IllegalStateException("No valid image found")
+
+        anilistPosterCache.put(anilistId, poster)
+        writeDiskTextCache(
+            key = cacheKey,
+            namespace = AnimeUnityCache.NAMESPACE_EXTERNAL,
+            payload = poster,
+            ttlMs = EXTERNAL_CACHE_TTL_MS,
+            priority = CACHE_PRIORITY_STANDARD,
+        )
+        return poster
     }
 
     private suspend fun getTrailerUrl(anime: Anime): String? {
-        getAniListTrailer(anime)?.let { return it }
-        return getJikanTrailer(anime)
+        val cacheKey = trailerUrlCacheKey(anime)
+        trailerUrlCache.get(cacheKey)?.let { return it }
+        readDiskTextCache(cacheKey)?.let { cachedTrailer ->
+            trailerUrlCache.put(cacheKey, cachedTrailer)
+            return cachedTrailer
+        }
+
+        val trailerUrl = getAniListTrailer(anime) ?: getJikanTrailer(anime)
+        if (trailerUrl != null) {
+            trailerUrlCache.put(cacheKey, trailerUrl)
+            writeDiskTextCache(
+                key = cacheKey,
+                namespace = AnimeUnityCache.NAMESPACE_EXTERNAL,
+                payload = trailerUrl,
+                ttlMs = EXTERNAL_CACHE_TTL_MS,
+                priority = CACHE_PRIORITY_STANDARD,
+            )
+        }
+        return trailerUrl
     }
 
     private suspend fun getAniListTrailer(anime: Anime): String? {
@@ -849,7 +1772,7 @@ class AnimeUnity(
         }
 
         val body = mapOf("query" to query, "variables" to variables)
-        val response = runCatching { app.post("https://graphql.anilist.co", data = body).text }.getOrNull()
+        val response = runCatchingCancellable { app.post("https://graphql.anilist.co", data = body).text }.getOrNull()
             ?: return null
         val media = runCatching { parseJson<AnilistResponse>(response).data.media }.getOrNull()
             ?: return null
@@ -894,7 +1817,7 @@ class AnimeUnity(
     private suspend fun getJikanTrailer(anime: Anime): String? {
         anime.malId?.let { malId ->
             val url = "https://api.jikan.moe/v4/anime/$malId/full"
-            val response = runCatching { app.get(url).text }.getOrNull() ?: return null
+            val response = runCatchingCancellable { app.get(url).text }.getOrNull() ?: return null
             val trailer = runCatching { parseJson<JikanFullResponse>(response).data.trailer }.getOrNull()
             return normalizeTrailerUrl(trailer)
         }
@@ -906,7 +1829,7 @@ class AnimeUnity(
             .build()
             .toString()
 
-        val response = runCatching { app.get(searchUrl).text }.getOrNull() ?: return null
+        val response = runCatchingCancellable { app.get(searchUrl).text }.getOrNull() ?: return null
         val candidates = runCatching { parseJson<JikanSearchResponse>(response).data }.getOrNull().orEmpty()
         if (candidates.isEmpty()) return null
 
@@ -931,86 +1854,227 @@ class AnimeUnity(
 
     override suspend fun getMainPage(page: Int, request: MainPageRequest): HomePageResponse {
         val sectionData = decodeMainPageSectionData(request.data)
+        val cacheKey = homeCacheKey(sectionData, page, request.name)
 
-        if (sectionData.key == "latest") {
-            return getLatestEpisodesMainPage(page, request.name)
+        return when (sectionData.key) {
+            AnimeUnitySections.LATEST -> getLatestEpisodesMainPage(page, request.name, cacheKey)
+            AnimeUnitySections.CALENDAR -> getCalendarMainPage(page, request.name, sectionData.baseUrl, cacheKey)
+            AnimeUnitySections.RANDOM -> getRandomMainPage(page, request.name, sectionData.baseUrl)
+            else -> getArchiveMainPage(page, request.name, sectionData, cacheKey)
         }
-        if (sectionData.key == "calendar") {
-            return getCalendarMainPage(page, request.name, sectionData.baseUrl)
-        }
-        if (sectionData.key == "random") {
-            return getRandomMainPage(page, request.name, sectionData.baseUrl)
+    }
+
+    private fun buildHomePageResponse(
+        sectionTitle: String,
+        responses: List<SearchResponse>,
+        hasNextPage: Boolean = false,
+    ): HomePageResponse {
+        return newHomePageResponse(
+            HomePageList(
+                name = sectionTitle,
+                list = responses,
+                isHorizontalImages = false,
+            ),
+            hasNextPage,
+        )
+    }
+
+    private fun emptyHomePageResponse(sectionTitle: String): HomePageResponse {
+        return buildHomePageResponse(sectionTitle, emptyList())
+    }
+
+    private suspend fun getArchiveMainPage(
+        page: Int,
+        sectionTitle: String,
+        sectionData: MainPageSectionData,
+        cacheKey: String,
+    ): HomePageResponse {
+        if (page > 1) {
+            return emptyHomePageResponse(sectionTitle)
         }
 
+        val sectionCount = getSectionCount(sectionData.key)
+        val allowStaleCache = shouldUseStaleWhileRevalidate(sectionData.key)
+        val cachedArchivePage = readDiskCache<ArchivePageResult>(cacheKey, allowExpired = allowStaleCache)
+        if (cachedArchivePage != null) {
+            if (allowStaleCache) {
+                revalidateArchiveMainPage(cacheKey, sectionData, page)
+            }
+            return buildArchiveHomePageResponse(sectionTitle, cachedArchivePage, sectionCount)
+        }
+
+        val archivePage = fetchArchiveMainPageData(sectionData, page, sectionCount)
+        writeDiskCache(
+            key = cacheKey,
+            namespace = AnimeUnityCache.NAMESPACE_HOME,
+            payload = archivePage,
+            ttlMs = getHomeCacheTtlMs(sectionData.key),
+            priority = getHomeCachePriority(sectionData.key),
+        )
+        return buildArchiveHomePageResponse(sectionTitle, archivePage, sectionCount)
+    }
+
+    private suspend fun buildArchiveHomePageResponse(
+        sectionTitle: String,
+        archivePage: ArchivePageResult,
+        sectionCount: Int,
+    ): HomePageResponse {
+        val responses = if (archivePage.titles.isNotEmpty()) {
+            searchResponseBuilder(archivePage.titles, limit = sectionCount)
+        } else {
+            emptyList()
+        }
+        return buildHomePageResponse(sectionTitle, responses)
+    }
+
+    private suspend fun fetchArchiveMainPageData(
+        sectionData: MainPageSectionData,
+        page: Int,
+        sectionCount: Int = getSectionCount(sectionData.key),
+    ): ArchivePageResult {
         val url = sectionData.baseUrl + "get-animes"
         ensureHeadersAndCookies()
 
         val requestData = getDataPerHomeSection(sectionData.key)
-        val sectionCount = getSectionCount(sectionData.key)
-        val archivePage = fetchArchiveSectionPage(url, requestData, page, sectionCount)
-        return newHomePageResponse(
-            HomePageList(
-                name = request.name,
-                list = if (archivePage.titles.isNotEmpty()) {
-                    searchResponseBuilder(archivePage.titles)
-                } else {
-                    emptyList()
-                },
-                isHorizontalImages = false
-            ),
-            archivePage.hasNextPage
+        return fetchArchiveSectionPage(url, requestData, page, sectionCount)
+    }
+
+    private fun revalidateArchiveMainPage(
+        cacheKey: String,
+        sectionData: MainPageSectionData,
+        page: Int,
+    ) {
+        val cachedFirstIdentity = readDiskCache<ArchivePageResult>(
+            cacheKey,
+            allowExpired = true,
+        )?.firstIdentity()
+
+        revalidateInBackground(cacheKey) {
+            val freshArchivePage = fetchArchiveMainPageData(sectionData, page)
+            if (freshArchivePage.firstIdentity() != cachedFirstIdentity) {
+                writeDiskCache(
+                    key = cacheKey,
+                    namespace = AnimeUnityCache.NAMESPACE_HOME,
+                    payload = freshArchivePage,
+                    ttlMs = getHomeCacheTtlMs(sectionData.key),
+                    priority = getHomeCachePriority(sectionData.key),
+                )
+            }
+        }
+    }
+
+    private suspend fun getLatestEpisodesMainPage(
+        page: Int,
+        sectionTitle: String,
+        cacheKey: String,
+    ): HomePageResponse {
+        val sectionCount = getSectionCount(AnimeUnitySections.LATEST)
+        if (page > 1) {
+            return emptyHomePageResponse(sectionTitle)
+        }
+
+        val cachedLatestEpisodes = readDiskCache<List<LatestEpisodeItem>>(
+            cacheKey,
+            allowExpired = true,
+        )
+        if (cachedLatestEpisodes != null) {
+            revalidateLatestEpisodes(cacheKey)
+            return buildLatestEpisodesHomePageResponse(sectionTitle, cachedLatestEpisodes, sectionCount)
+        }
+
+        val latestEpisodes = fetchLatestEpisodes()
+        writeDiskCache(
+            key = cacheKey,
+            namespace = AnimeUnityCache.NAMESPACE_HOME,
+            payload = latestEpisodes,
+            ttlMs = LATEST_CACHE_TTL_MS,
+            priority = getHomeCachePriority(AnimeUnitySections.LATEST),
+        )
+        return buildLatestEpisodesHomePageResponse(sectionTitle, latestEpisodes, sectionCount)
+    }
+
+    private suspend fun buildLatestEpisodesHomePageResponse(
+        sectionTitle: String,
+        latestEpisodes: List<LatestEpisodeItem>,
+        sectionCount: Int,
+    ): HomePageResponse {
+        return buildHomePageResponse(
+            sectionTitle,
+            latestEpisodesResponseBuilder(latestEpisodes, sectionCount),
         )
     }
 
-    private suspend fun getLatestEpisodesMainPage(page: Int, sectionTitle: String): HomePageResponse {
-        val sectionCount = getSectionCount("latest")
-        if (page > 1) {
-            return newHomePageResponse(
-                HomePageList(name = sectionTitle, list = emptyList(), isHorizontalImages = false),
-                false
-            )
-        }
-
+    private suspend fun fetchLatestEpisodes(): List<LatestEpisodeItem> {
         val latestEpisodesJson = app.get("$mainUrl/?page=1").document
             .selectFirst("#ultimi-episodi layout-items")
             ?.attr("items-json")
             .orEmpty()
 
-        val latestEpisodes = latestEpisodesJson
+        return latestEpisodesJson
             .takeIf(String::isNotBlank)
             ?.let { json ->
                 runCatching { parseJson<LatestEpisodesPage>(json).episodes }.getOrDefault(emptyList())
             }
-            ?.take(sectionCount)
             ?: emptyList()
+    }
 
-        return newHomePageResponse(
-            HomePageList(
-                name = sectionTitle,
-                list = latestEpisodesResponseBuilder(latestEpisodes),
-                isHorizontalImages = false
-            ),
-            false
-        )
+    private fun revalidateLatestEpisodes(cacheKey: String) {
+        val cachedFirstIdentity = readDiskCache<List<LatestEpisodeItem>>(
+            cacheKey,
+            allowExpired = true,
+        )?.firstIdentity()
+
+        revalidateInBackground(cacheKey) {
+            val freshEpisodes = fetchLatestEpisodes()
+            if (freshEpisodes.firstIdentity() != cachedFirstIdentity) {
+                writeDiskCache(
+                    key = cacheKey,
+                    namespace = AnimeUnityCache.NAMESPACE_HOME,
+                    payload = freshEpisodes,
+                    ttlMs = LATEST_CACHE_TTL_MS,
+                    priority = getHomeCachePriority(AnimeUnitySections.LATEST),
+                )
+            }
+        }
     }
 
     private suspend fun getCalendarMainPage(
         page: Int,
         sectionTitle: String,
         requestUrl: String,
+        cacheKey: String,
     ): HomePageResponse {
         val currentDay = getCurrentItalianDayName()
         val calendarTitle = "$sectionTitle ($currentDay)"
-        val sectionCount = getSectionCount("calendar")
+        val sectionCount = getSectionCount(AnimeUnitySections.CALENDAR)
 
         if (page > 1) {
-            return newHomePageResponse(
-                HomePageList(name = calendarTitle, list = emptyList(), isHorizontalImages = false),
-                false
-            )
+            return emptyHomePageResponse(calendarTitle)
         }
 
-        val calendarAnime = app.get(requestUrl).document
+        val cachedCalendarAnime = readDiskCache<List<CalendarAnimeItem>>(cacheKey)
+        if (cachedCalendarAnime != null) {
+            return buildCalendarHomePageResponse(calendarTitle, cachedCalendarAnime, sectionCount)
+        }
+
+        val calendarAnime = fetchCalendarAnime(requestUrl, currentDay)
+        writeDiskCache(
+            key = cacheKey,
+            namespace = AnimeUnityCache.NAMESPACE_HOME,
+            payload = calendarAnime,
+            ttlMs = DAY_MS,
+            expiresAtMs = getHomeCacheExpirationMs(AnimeUnitySections.CALENDAR),
+            priority = getHomeCachePriority(AnimeUnitySections.CALENDAR),
+        )
+
+        return buildCalendarHomePageResponse(calendarTitle, calendarAnime, sectionCount)
+    }
+
+    private suspend fun fetchCalendarAnime(
+        requestUrl: String,
+        currentDay: String,
+    ): List<CalendarAnimeItem> {
+        return app.get(requestUrl).document
             .select("calendario-item")
             .mapNotNull { item ->
                 val animeJson = item.attr("a")
@@ -1020,23 +2084,21 @@ class AnimeUnity(
                 val episodeNumber = extractCalendarEpisodeNumber(item, anime)
 
                 if (normalizeDayName(anime.day) == normalizeDayName(currentDay)) {
-                    anime to episodeNumber
+                    CalendarAnimeItem(anime, episodeNumber)
                 } else {
                     null
                 }
             }
-            .distinctBy { it.first.contentKey() }
-            .take(sectionCount)
+    }
 
-        return newHomePageResponse(
-            HomePageList(
-                name = calendarTitle,
-                list = calendarAnime.amap { (anime, ep) ->
-                    searchResponseBuilder(listOf(anime), ep).first()
-                },
-                isHorizontalImages = false
-            ),
-            false
+    private suspend fun buildCalendarHomePageResponse(
+        calendarTitle: String,
+        calendarAnime: List<CalendarAnimeItem>,
+        sectionCount: Int,
+    ): HomePageResponse {
+        return buildHomePageResponse(
+            calendarTitle,
+            calendarResponseBuilder(calendarAnime, sectionCount),
         )
     }
 
@@ -1059,19 +2121,31 @@ class AnimeUnity(
         sectionTitle: String,
         requestUrl: String,
     ): HomePageResponse {
+        if (page > 1) {
+            return emptyHomePageResponse(sectionTitle)
+        }
+
         val url = "${requestUrl}get-animes"
         ensureHeadersAndCookies()
 
-        val sectionCount = getSectionCount("random")
-        val (titles, total) = fetchRandomTitles(url, sectionCount)
+        val sessionKey = "$mainUrl|$requestUrl|${displayCacheKey()}"
+        val seenIds = synchronized(randomSessionSeenIds) {
+            randomSessionSeenIds.getOrPut(sessionKey) { mutableSetOf() }
+        }
+        val sectionCount = getSectionCount(AnimeUnitySections.RANDOM)
+        val (titles, total) = fetchRandomTitles(url, sectionCount, seenIds)
+        synchronized(randomSessionSeenIds) {
+            val updatedSeenIds = randomSessionSeenIds.getOrPut(sessionKey) { mutableSetOf() }
+            titles.forEach { updatedSeenIds += it.id }
+            if (total > 0 && updatedSeenIds.size >= total) {
+                updatedSeenIds.clear()
+                titles.forEach { updatedSeenIds += it.id }
+            }
+        }
 
-        return newHomePageResponse(
-            HomePageList(
-                name = sectionTitle,
-                list = searchResponseBuilder(titles),
-                isHorizontalImages = false
-            ),
-            page < 5 && total > sectionCount
+        return buildHomePageResponse(
+            sectionTitle,
+            searchResponseBuilder(titles, limit = sectionCount),
         )
     }
 
@@ -1090,11 +2164,11 @@ class AnimeUnity(
     }
 
     private fun getDataPerHomeSection(section: String) = when (section) {
-        "advanced" -> AnimeUnityPlugin.getAdvancedSearchRequestData(sharedPref)
-        "popular" -> RequestData(orderBy = Str("Popolarità"), dubbed = 0)
-        "upcoming" -> RequestData(status = Str("In Uscita"), dubbed = 0)
-        "best" -> RequestData(orderBy = Str("Valutazione"), dubbed = 0)
-        "ongoing" -> RequestData(orderBy = Str("Popolarità"), status = Str("In Corso"), dubbed = 0)
+        AnimeUnitySections.ADVANCED -> AnimeUnityPlugin.getAdvancedSearchRequestData(sharedPref)
+        AnimeUnitySections.POPULAR -> RequestData(orderBy = Str("Popolarità"), dubbed = 0)
+        AnimeUnitySections.UPCOMING -> RequestData(status = Str("In Uscita"), dubbed = 0)
+        AnimeUnitySections.BEST -> RequestData(orderBy = Str("Valutazione"), dubbed = 0)
+        AnimeUnitySections.ONGOING -> RequestData(orderBy = Str("Popolarità"), status = Str("In Corso"), dubbed = 0)
         else -> RequestData()
     }
 
@@ -1112,9 +2186,45 @@ class AnimeUnity(
     }
 
     override suspend fun load(url: String): LoadResponse {
-        ensureHeadersAndCookies(forceReset = true)
-        val animePage = app.get(url).document
-        val currentPageData = parseAnimePageData(animePage)
+        val cacheKeys = loadCacheKeys(url)
+        val cacheKey = cacheKeys.first()
+        animeLoadDataCache.get(cacheKey)?.let { cachedLoadData ->
+            return buildAnimeLoadResponse(cachedLoadData)
+        }
+
+        val cachedData = cacheKeys.firstNotNullOfOrNull { candidateKey ->
+            readDiskCacheRecord<AnimeLoadCacheData>(
+                candidateKey,
+                allowExpired = true,
+            )?.let { candidateKey to it }
+        }
+        if (cachedData != null) {
+            val (resolvedCacheKey, cachedRecord) = cachedData
+            val (loadData, record) = cachedRecord
+            val isCompleted = getShowStatus(loadData.primaryAnime().status) == ShowStatus.Completed
+            if (!record.isExpired || !isCompleted) {
+                animeLoadDataCache.put(cacheKey, loadData)
+                if (resolvedCacheKey != cacheKey) {
+                    writeAnimeLoadCacheData(cacheKey, loadData)
+                }
+                if (!isCompleted) {
+                    revalidateAnimeLoad(cacheKey, url, loadData)
+                }
+                return buildAnimeLoadResponse(loadData)
+            }
+        }
+
+        val loadData = fetchAnimeLoadCacheData(url, forceRefresh = false)
+        writeAnimeLoadCacheData(cacheKey, loadData)
+        return buildAnimeLoadResponse(loadData)
+    }
+
+    private suspend fun fetchAnimeLoadCacheData(
+        url: String,
+        forceRefresh: Boolean,
+    ): AnimeLoadCacheData {
+        ensureHeadersAndCookies(forceReset = forceRefresh)
+        val currentPageData = fetchAnimePageData(url, forceRefresh = forceRefresh)
         val currentAnime = currentPageData.anime
         val shouldMergeVariants = shouldUseUnifiedDubSubCards()
         val variants = if (shouldMergeVariants) findAnimeVariants(currentAnime) else listOf(currentAnime)
@@ -1122,26 +2232,107 @@ class AnimeUnity(
         val subAnime = variants.firstOrNull { !isDubAnime(it) } ?: currentAnime.takeIf { !isDubAnime(it) }
         val dubAnime = variants.firstOrNull { isDubAnime(it) } ?: currentAnime.takeIf { isDubAnime(it) }
 
-        val subPageData = when {
-            subAnime == null -> null
-            subAnime.id == currentAnime.id -> currentPageData
-            !shouldMergeVariants -> null
-            else -> fetchAnimePageData(getAnimeUrl(subAnime))
-        }
+        val (subPageData, dubPageData) = coroutineScope {
+            val subPageDeferred = async(Dispatchers.IO) {
+                when {
+                    subAnime == null -> null
+                    subAnime.id == currentAnime.id -> currentPageData
+                    !shouldMergeVariants -> null
+                    else -> fetchAnimePageData(getAnimeUrl(subAnime), forceRefresh = forceRefresh)
+                }
+            }
+            val dubPageDeferred = async(Dispatchers.IO) {
+                when {
+                    dubAnime == null -> null
+                    dubAnime.id == currentAnime.id -> currentPageData
+                    !shouldMergeVariants -> null
+                    else -> fetchAnimePageData(getAnimeUrl(dubAnime), forceRefresh = forceRefresh)
+                }
+            }
 
-        val dubPageData = when {
-            dubAnime == null -> null
-            dubAnime.id == currentAnime.id -> currentPageData
-            !shouldMergeVariants -> null
-            else -> fetchAnimePageData(getAnimeUrl(dubAnime))
+            subPageDeferred.await() to dubPageDeferred.await()
         }
 
         val primaryAnime = subPageData?.anime ?: dubPageData?.anime ?: currentAnime
+        val primaryMalId = primaryAnime.malId ?: variants.firstNotNullOfOrNull { it.malId }
+        val primaryAniListId = primaryAnime.anilistId ?: variants.firstNotNullOfOrNull { it.anilistId }
+        val (episodeMetadata, trailerUrl) = coroutineScope {
+            val episodeMetadataDeferred = async(Dispatchers.IO) {
+                fetchAniZipMetadata(primaryMalId, primaryAniListId)
+            }
+            val trailerUrlDeferred = async(Dispatchers.IO) {
+                getTrailerUrl(primaryAnime)
+            }
+
+            episodeMetadataDeferred.await() to trailerUrlDeferred.await()
+        }
+
+        return AnimeLoadCacheData(
+            currentPageData = currentPageData,
+            variants = variants,
+            subPageData = subPageData,
+            dubPageData = dubPageData,
+            episodeMetadata = episodeMetadata,
+            trailerUrl = trailerUrl,
+            fingerprint = buildAnimeLoadFingerprint(
+                primaryAnime = primaryAnime,
+                subPageData = subPageData,
+                dubPageData = dubPageData,
+                episodeMetadata = episodeMetadata,
+            ),
+        )
+    }
+
+    private fun writeAnimeLoadCacheData(cacheKey: String, loadData: AnimeLoadCacheData) {
+        val primaryAnime = loadData.primaryAnime()
+        val isCompleted = getShowStatus(primaryAnime.status) == ShowStatus.Completed
+        animeLoadDataCache.put(cacheKey, loadData)
+        writeDiskCache(
+            key = cacheKey,
+            namespace = AnimeUnityCache.NAMESPACE_DETAIL,
+            payload = loadData,
+            ttlMs = getAnimeDetailTtlMs(primaryAnime),
+            priority = if (isCompleted) CACHE_PRIORITY_IMPORTANT else CACHE_PRIORITY_DETAIL,
+            pinned = true,
+        )
+    }
+
+    private fun revalidateAnimeLoad(
+        cacheKey: String,
+        url: String,
+        cachedData: AnimeLoadCacheData,
+    ) {
+        revalidateInBackground(cacheKey) {
+            val freshData = fetchAnimeLoadCacheData(url, forceRefresh = true)
+            if (
+                freshData.totalEpisodeCount() != cachedData.totalEpisodeCount() ||
+                freshData.fingerprint != cachedData.fingerprint
+            ) {
+                writeAnimeLoadCacheData(cacheKey, freshData)
+            }
+        }
+    }
+
+    private suspend fun buildAnimeLoadResponse(loadData: AnimeLoadCacheData): LoadResponse {
+        val currentPageData = loadData.currentPageData
+        val variants = loadData.variants
+        val subPageData = loadData.subPageData
+        val dubPageData = loadData.dubPageData
+        val primaryAnime = loadData.primaryAnime()
+        val primaryMalId = primaryAnime.malId ?: variants.firstNotNullOfOrNull { it.malId }
+        val primaryAniListId = primaryAnime.anilistId ?: variants.firstNotNullOfOrNull { it.anilistId }
         val title = getAnimeTitle(primaryAnime)
-        val relatedAnimes = groupAnimeCards(currentPageData.relatedAnime).amap { entry ->
+        val animePoster = getImage(primaryAnime.imageUrl, primaryAniListId)
+        val episodeFallbackPosterUrl = primaryAnime.cover?.let(::getBanner) ?: animePoster
+        val episodeMetadata = loadData.episodeMetadata
+        val episodeMetadataIndex = buildEpisodeMetadataIndex(episodeMetadata)
+        val syncMalId = primaryMalId ?: episodeMetadata?.mappings?.malId
+        val syncAniListId = primaryAniListId ?: episodeMetadata?.mappings?.anilistId
+        val syncKitsuId = episodeMetadata?.mappings?.kitsuId
+        val relatedAnimes = groupAnimeCards(currentPageData.relatedAnime).safeAmap(concurrency = 6) { entry ->
             val anime = entry.anime
             val relatedTitle = getAnimeTitle(anime)
-            val poster = getImage(anime.imageUrl, anime.anilistId)
+            val poster = runCatchingCancellable { getImage(anime.imageUrl, anime.anilistId) }.getOrNull()
             newAnimeSearchResponse(
                 name = withoutDubSuffix(relatedTitle),
                 url = "$mainUrl/anime/${anime.id}-${anime.slug}",
@@ -1149,49 +2340,34 @@ class AnimeUnity(
                 else if (anime.type == "Movie" || anime.episodesCount == 1) TvType.AnimeMovie
                 else TvType.OVA
             ) {
-                if (shouldShowDubSub()) {
-                    addDubStatus(getMiniCardDubStatus(entry.hasDub))
-                }
-                addPoster(poster)
+                applyCardDisplayState(
+                    response = this,
+                    badges = entry.badges,
+                    poster = poster,
+                    score = null,
+                )
             }
         }
 
         val subEpisodeMap = buildEpisodeSourceMap(subPageData?.anime, subPageData?.episodes.orEmpty())
         val dubEpisodeMap = buildEpisodeSourceMap(dubPageData?.anime, dubPageData?.episodes.orEmpty())
-        val subEpisodes = if (shouldMergeVariants) {
-            buildMergedEpisodes(
-                primaryEpisodes = subEpisodeMap,
-                fallbackEpisodes = dubEpisodeMap,
-                subEpisodes = subEpisodeMap,
-                dubEpisodes = dubEpisodeMap,
-            )
-        } else {
-            buildMergedEpisodes(
-                primaryEpisodes = subEpisodeMap,
-                fallbackEpisodes = linkedMapOf(),
-                subEpisodes = subEpisodeMap,
-                dubEpisodes = linkedMapOf(),
-            )
-        }
-        val dubEpisodes = if (shouldMergeVariants) {
-            buildMergedEpisodes(
-                primaryEpisodes = dubEpisodeMap,
-                fallbackEpisodes = subEpisodeMap,
-                subEpisodes = subEpisodeMap,
-                dubEpisodes = dubEpisodeMap,
-                fallbackNamePrefix = "[SUB] - ",
-            )
-        } else {
-            buildMergedEpisodes(
-                primaryEpisodes = dubEpisodeMap,
-                fallbackEpisodes = linkedMapOf(),
-                subEpisodes = linkedMapOf(),
-                dubEpisodes = dubEpisodeMap,
-            )
-        }
+        val subEpisodes = buildEpisodes(
+            episodes = subEpisodeMap,
+            subEpisodes = subEpisodeMap,
+            dubEpisodes = dubEpisodeMap,
+            episodeMetadataIndex = episodeMetadataIndex,
+            episodeFallbackPosterUrl = episodeFallbackPosterUrl,
+        )
+        val dubEpisodes = buildEpisodes(
+            episodes = dubEpisodeMap,
+            subEpisodes = subEpisodeMap,
+            dubEpisodes = dubEpisodeMap,
+            episodeMetadataIndex = episodeMetadataIndex,
+            episodeFallbackPosterUrl = episodeFallbackPosterUrl,
+        )
         val hasSub = subEpisodeMap.isNotEmpty()
         val hasDub = dubEpisodeMap.isNotEmpty()
-        val trailerUrl = getTrailerUrl(primaryAnime)
+        val trailerUrl = loadData.trailerUrl
 
         return newAnimeLoadResponse(
             name = title.replace(" (ITA)", ""),
@@ -1200,7 +2376,7 @@ class AnimeUnity(
             else if (primaryAnime.type == "Movie" || primaryAnime.episodesCount == 1) TvType.AnimeMovie
             else TvType.OVA,
         ) {
-            this.posterUrl = getImage(primaryAnime.imageUrl, primaryAnime.anilistId)
+            this.posterUrl = animePoster
             primaryAnime.cover?.let { this.backgroundPosterUrl = getBanner(it) }
             this.year = primaryAnime.date.toIntOrNull()
             addScore(primaryAnime.score)
@@ -1217,8 +2393,9 @@ class AnimeUnity(
                     addEpisodes(DubStatus.Subbed, subEpisodes)
                 }
             }
-            addAniListId(primaryAnime.anilistId)
-            addMalId(primaryAnime.malId)
+            addAniListId(syncAniListId)
+            addMalId(syncMalId)
+            addKitsuId(syncKitsuId)
             if (trailerUrl != null) {
                 addTrailer(trailerUrl)
             }
@@ -1239,10 +2416,10 @@ class AnimeUnity(
 
     private fun getBanner(imageUrl: String): String {
         if (imageUrl.isNotEmpty()) {
-            try {
-                val fileName = imageUrl.substringAfterLast("/")
+            val fileName = imageUrl.substringAfterLast("/")
+            if (fileName.isNotBlank()) {
                 return "https://${getImageCdnHost()}/anime/$fileName"
-            } catch (_: Exception) {}
+            }
         }
         return imageUrl
     }
@@ -1260,22 +2437,24 @@ class AnimeUnity(
 
         val shouldLabelSources = playerSources.size > 1
 
-        playerSources.forEach { playerSource ->
-            val document = app.get(playerSource.url).document
-            val sourceUrl = document.select("video-player").attr("embed_url")
-            if (sourceUrl.isBlank()) return@forEach
-
-            val sourceSuffix = if (shouldLabelSources) " ${playerSource.label}" else ""
-            VixCloudExtractor(
-                sourceName = "VixCloud$sourceSuffix",
-                displayName = "AnimeUnity$sourceSuffix",
-            ).getUrl(
-                url = sourceUrl,
-                referer = mainUrl,
-                subtitleCallback = subtitleCallback,
-                callback = callback
-            )
+        val sourceTasks = playerSources.map { playerSource ->
+            suspend {
+                val sourceUrl = getPlayerEmbedUrl(playerSource.url)
+                if (!sourceUrl.isNullOrBlank()) {
+                    val sourceSuffix = if (shouldLabelSources) " ${playerSource.label}" else ""
+                    VixCloudExtractor(
+                        sourceName = "VixCloud$sourceSuffix",
+                        displayName = "AnimeUnity$sourceSuffix",
+                    ).getUrl(
+                        url = sourceUrl,
+                        referer = mainUrl,
+                        subtitleCallback = subtitleCallback,
+                        callback = callback
+                    )
+                }
+            }
         }
+        runLimitedAsync(concurrency = 2, *sourceTasks.toTypedArray())
 
         return true
     }

--- a/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnityCache.kt
+++ b/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnityCache.kt
@@ -1,0 +1,284 @@
+package it.dogior.hadEnough
+
+import android.content.Context
+import org.json.JSONObject
+import java.io.File
+import java.security.MessageDigest
+
+object AnimeUnityCache {
+    private const val CACHE_SCHEMA = 1
+    private const val CACHE_FILE_EXTENSION = "json"
+    private const val MAX_CACHE_BYTES = 250L * 1024L * 1024L
+    private const val MAX_DETAIL_ENTRIES = 750
+
+    const val NAMESPACE_HOME = "home"
+    const val NAMESPACE_DETAIL = "detail"
+    const val NAMESPACE_ARCHIVE = "archive"
+    const val NAMESPACE_ANIME_PAGE = "anime_page"
+    const val NAMESPACE_EXTERNAL = "external"
+
+    data class CacheRecord(
+        val payload: String,
+        val createdAtMs: Long,
+        val updatedAtMs: Long,
+        val expiresAtMs: Long,
+        val isExpired: Boolean,
+    )
+
+    data class CacheStats(
+        val entryCount: Int,
+        val detailEntryCount: Int,
+        val animePageEntryCount: Int,
+        val expiredEntryCount: Int,
+        val totalBytes: Long,
+    )
+
+    private data class CacheFileMeta(
+        val file: File,
+        val namespace: String,
+        val lastAccessedAtMs: Long,
+        val priority: Int,
+        val pinned: Boolean,
+        val isExpired: Boolean,
+        val sizeBytes: Long,
+    )
+
+    @Volatile
+    private var cacheDirectory: File? = null
+
+    fun init(context: Context) {
+        cacheDirectory = File(context.filesDir, "animeunity_cache").apply {
+            mkdirs()
+        }
+    }
+
+    fun read(key: String, allowExpired: Boolean = false): CacheRecord? {
+        val file = getCacheFile(key) ?: return null
+        if (!file.exists()) return null
+
+        return synchronized(this) {
+            val json = readValidatedJson(file, expectedKey = key)
+                ?: return@synchronized null
+
+            val now = System.currentTimeMillis()
+            val expiresAtMs = json.optLong("expiresAtMs", 0L)
+            val isExpired = expiresAtMs > 0L && now >= expiresAtMs
+            if (isExpired && !allowExpired) {
+                file.delete()
+                return@synchronized null
+            }
+
+            file.setLastModified(now)
+
+            CacheRecord(
+                payload = json.optString("payload"),
+                createdAtMs = json.optLong("createdAtMs", now),
+                updatedAtMs = json.optLong("updatedAtMs", now),
+                expiresAtMs = expiresAtMs,
+                isExpired = isExpired,
+            )
+        }
+    }
+
+    fun write(
+        key: String,
+        namespace: String,
+        payload: String,
+        ttlMs: Long,
+        expiresAtMs: Long? = null,
+        priority: Int = 0,
+        pinned: Boolean = false,
+    ) {
+        val file = getCacheFile(key) ?: return
+        val now = System.currentTimeMillis()
+        val expiration = expiresAtMs ?: (now + ttlMs)
+
+        synchronized(this) {
+            file.parentFile?.mkdirs()
+            val createdAtMs = readValidatedJson(file, expectedKey = key)
+                ?.optLong("createdAtMs", now)
+                ?: now
+            val json = JSONObject().apply {
+                put("schema", CACHE_SCHEMA)
+                put("key", key)
+                put("namespace", namespace)
+                put("createdAtMs", createdAtMs)
+                put("updatedAtMs", now)
+                put("expiresAtMs", expiration)
+                put("lastAccessedAtMs", now)
+                put("priority", priority)
+                put("pinned", pinned)
+                put("payload", payload)
+            }
+
+            if (writeJsonFile(file, json)) {
+                trimIfNeeded()
+            }
+        }
+    }
+
+    fun remove(key: String) {
+        synchronized(this) {
+            getCacheFile(key)?.delete()
+        }
+    }
+
+    fun clear() {
+        synchronized(this) {
+            cacheDirectory?.deleteRecursively()
+            cacheDirectory?.mkdirs()
+        }
+    }
+
+    fun stats(): CacheStats {
+        return synchronized(this) {
+            val entries = readAllMeta()
+            CacheStats(
+                entryCount = entries.size,
+                detailEntryCount = entries.count { it.namespace == NAMESPACE_DETAIL },
+                animePageEntryCount = entries.count { it.namespace == NAMESPACE_ANIME_PAGE },
+                expiredEntryCount = entries.count { it.isExpired },
+                totalBytes = entries.sumOf { it.sizeBytes },
+            )
+        }
+    }
+
+    private fun getCacheFile(key: String): File? {
+        val directory = cacheDirectory ?: return null
+        val hash = sha256(key)
+        return File(directory, "$hash.$CACHE_FILE_EXTENSION")
+    }
+
+    private fun readAllMeta(): List<CacheFileMeta> {
+        val directory = cacheDirectory ?: return emptyList()
+        val files = directory.listFiles { file ->
+            file.isFile && file.extension == CACHE_FILE_EXTENSION
+        } ?: return emptyList()
+        val now = System.currentTimeMillis()
+
+        return files.mapNotNull { file ->
+            val json = readValidatedJson(file) ?: return@mapNotNull null
+            val expiresAtMs = json.optLong("expiresAtMs", 0L)
+
+            CacheFileMeta(
+                file = file,
+                namespace = json.optString("namespace"),
+                lastAccessedAtMs = maxOf(json.optLong("lastAccessedAtMs", 0L), file.lastModified()),
+                priority = json.optInt("priority", 0),
+                pinned = json.optBoolean("pinned", false),
+                isExpired = expiresAtMs > 0L && now >= expiresAtMs,
+                sizeBytes = file.length(),
+            )
+        }
+    }
+
+    private fun trimIfNeeded() {
+        val entries = readAllMeta()
+        var totalBytes = entries.sumOf { it.sizeBytes }
+        var detailEntries = entries.count { it.namespace == NAMESPACE_DETAIL }
+        if (totalBytes <= MAX_CACHE_BYTES && detailEntries <= MAX_DETAIL_ENTRIES) return
+
+        fun needsTrim(): Boolean {
+            return totalBytes > MAX_CACHE_BYTES || detailEntries > MAX_DETAIL_ENTRIES
+        }
+
+        fun trim(candidates: List<CacheFileMeta>) {
+            for (entry in candidates) {
+                val shouldTrimByBytes = totalBytes > MAX_CACHE_BYTES
+                val shouldTrimByDetailCount =
+                    detailEntries > MAX_DETAIL_ENTRIES && entry.namespace == NAMESPACE_DETAIL
+                if (!shouldTrimByBytes && !shouldTrimByDetailCount) break
+
+                if (entry.file.delete()) {
+                    totalBytes -= entry.sizeBytes
+                    if (entry.namespace == NAMESPACE_DETAIL) detailEntries -= 1
+                }
+            }
+        }
+
+        trim(sortedTrimCandidates(entries.filterNot { it.pinned }))
+        if (needsTrim()) {
+            trim(sortedTrimCandidates(entries.filter { it.pinned }))
+        }
+    }
+
+    private fun sortedTrimCandidates(entries: List<CacheFileMeta>): List<CacheFileMeta> {
+        return entries.sortedWith(
+            compareBy<CacheFileMeta>(
+                { !it.isExpired },
+                { namespaceTrimRank(it.namespace) },
+                { it.priority },
+                { it.lastAccessedAtMs },
+            )
+        )
+    }
+
+    private fun namespaceTrimRank(namespace: String): Int {
+        return when (namespace) {
+            NAMESPACE_ARCHIVE -> 0
+            NAMESPACE_HOME -> 1
+            NAMESPACE_EXTERNAL -> 2
+            NAMESPACE_ANIME_PAGE -> 3
+            NAMESPACE_DETAIL -> 4
+            else -> 2
+        }
+    }
+
+    private fun readValidatedJson(file: File, expectedKey: String? = null): JSONObject? {
+        val json = runCatching { JSONObject(file.readText()) }.getOrNull()
+        if (json == null) {
+            file.delete()
+            return null
+        }
+
+        val hasExpectedSchema = json.optInt("schema") == CACHE_SCHEMA
+        val hasExpectedKey = expectedKey == null || json.optString("key") == expectedKey
+        if (!hasExpectedSchema || !hasExpectedKey) {
+            file.delete()
+            return null
+        }
+
+        return json
+    }
+
+    private fun writeJsonFile(file: File, json: JSONObject): Boolean {
+        val parent = file.parentFile ?: return false
+        parent.mkdirs()
+
+        val tmpFile = File(parent, "${file.name}.tmp")
+        val backupFile = File(parent, "${file.name}.bak")
+
+        return try {
+            tmpFile.delete()
+            backupFile.delete()
+            tmpFile.writeText(json.toString())
+
+            val hadExistingFile = file.exists()
+            if (hadExistingFile && !file.renameTo(backupFile)) {
+                tmpFile.delete()
+                return false
+            }
+
+            if (tmpFile.renameTo(file)) {
+                backupFile.delete()
+                true
+            } else {
+                tmpFile.delete()
+                if (hadExistingFile) backupFile.renameTo(file)
+                false
+            }
+        } catch (_: Throwable) {
+            tmpFile.delete()
+            if (!file.exists() && backupFile.exists()) {
+                backupFile.renameTo(file)
+            }
+            false
+        }
+    }
+
+    private fun sha256(value: String): String {
+        val bytes = MessageDigest.getInstance("SHA-256")
+            .digest(value.toByteArray(Charsets.UTF_8))
+        return bytes.joinToString("") { "%02x".format(it) }
+    }
+}

--- a/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnityDTOs.kt
+++ b/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnityDTOs.kt
@@ -7,19 +7,19 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONArray
 import org.json.JSONObject
 
-// Sealed class to represent either Boolean or String
 sealed class BooleanOrString {
-    data class AsBoolean(val value: Boolean) : BooleanOrString(){
+    data class AsBoolean(val value: Boolean) : BooleanOrString() {
         override fun toString(): String {
             return value.toString()
         }
     }
+
     data class AsString(val value: String) : BooleanOrString()
 
-    fun getValue(): Any {
+    fun toJsonValue(): Any {
         return when (this) {
-            is AsBoolean -> this.value // Access boolean value
-            is AsString -> this.value  // Access string value
+            is AsBoolean -> value
+            is AsString -> value
         }
     }
 }
@@ -34,12 +34,12 @@ data class RequestData(
     val genres: Any = BooleanOrString.AsBoolean(false),
     /*** Inverno, Primavera, Estate, Autunno ***/
     val season: BooleanOrString = BooleanOrString.AsBoolean(false),
-    var offset: Int? = 0,
+    val offset: Int? = 0,
     val dubbed: Int = 1,
-){
+) {
     private fun serializeValue(value: Any): Any {
         return when (value) {
-            is BooleanOrString -> value.getValue()
+            is BooleanOrString -> value.toJsonValue()
             is List<*> -> JSONArray().apply {
                 value.filterIsInstance<ArchiveGenreOption>().forEach { genre ->
                     put(
@@ -94,6 +94,7 @@ data class Anime(
     @JsonProperty("plot") val plot: String,
     @JsonProperty("date") val date: String,
     @JsonProperty("episodes_count") val episodesCount: Int,
+    @JsonProperty("real_episodes_count") val realEpisodesCount: Int?,
     @JsonProperty("episodes_length") val episodesLength: Int,
     @JsonProperty("status") val status: String,
 //    @JsonProperty("imageurl_cover") val imageUrlCover: String?,
@@ -145,6 +146,7 @@ data class LatestEpisodeAnime(
     @JsonProperty("title") val title: String?,
     @JsonProperty("imageurl") val imageUrl: String?,
     @JsonProperty("episodes_count") val episodesCount: Int,
+    @JsonProperty("real_episodes_count") val realEpisodesCount: Int?,
     @JsonProperty("type") val type: String,
     @JsonProperty("slug") val slug: String,
     @JsonProperty("title_eng") val titleEng: String?,
@@ -238,3 +240,25 @@ data class JikanTrailer(
     @JsonProperty("embed_url") val embedUrl: String?
 )
 
+data class AniZipMetadata(
+    @JsonProperty("episodes") val episodes: Map<String, AniZipEpisode>?,
+    @JsonProperty("mappings") val mappings: AniZipMappings?
+)
+
+data class AniZipMappings(
+    @JsonProperty("mal_id") val malId: Int?,
+    @JsonProperty("anilist_id") val anilistId: Int?,
+    @JsonProperty("kitsu_id") val kitsuId: Int?
+)
+
+data class AniZipEpisode(
+    @JsonProperty("episode") val episode: String?,
+    @JsonProperty("airDate") val airDate: String?,
+    @JsonProperty("airDateUtc") val airDateUtc: String?,
+    @JsonProperty("runtime") val runtime: Int?,
+    @JsonProperty("image") val image: String?,
+    @JsonProperty("title") val title: Map<String, String?>?,
+    @JsonProperty("overview") val overview: String?,
+    @JsonProperty("summary") val summary: String?,
+    @JsonProperty("rating") val rating: String?
+)

--- a/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnityPlugin.kt
+++ b/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnityPlugin.kt
@@ -59,21 +59,14 @@ class AnimeUnityPlugin : Plugin() {
 
         const val DEFAULT_SITE_URL = "https://www.animeunity.so/"
         const val DEFAULT_SECTION_COUNT = 30
+        const val DEFAULT_RANDOM_COUNT = 10
         const val MAX_SECTION_COUNT = 100
         const val DEFAULT_ADVANCED_SEARCH_COUNT = MAX_SECTION_COUNT
-        const val DEFAULT_SECTION_ORDER = "latest,calendar,random,ongoing,popular,best,upcoming"
+        const val DEFAULT_SECTION_ORDER = AnimeUnitySections.DEFAULT_ORDER
         const val DEFAULT_UNIFY_DUB_SUB_CARDS = true
         private const val ARCHIVE_OLDEST_YEAR = 1966
-        private val defaultSectionKeys = DEFAULT_SECTION_ORDER.split(",")
-        private val validSectionKeys = listOf(
-            "latest",
-            "calendar",
-            "ongoing",
-            "popular",
-            "best",
-            "upcoming",
-            "random"
-        )
+        private val defaultSectionKeys = AnimeUnitySections.defaultOrderKeys
+        private val validSectionKeys = AnimeUnitySections.validKeys
 
         private val siteSchemeRegex = Regex("""(?i)^https?://""")
         private val validSiteHostRegex = Regex(
@@ -317,6 +310,7 @@ class AnimeUnityPlugin : Plugin() {
     private var sharedPref: SharedPreferences? = null
 
     override fun load(context: Context) {
+        AnimeUnityCache.init(context.applicationContext)
         sharedPref = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         activePlugin = this
         activeSharedPref = sharedPref

--- a/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnitySections.kt
+++ b/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnitySections.kt
@@ -1,0 +1,26 @@
+package it.dogior.hadEnough
+
+internal object AnimeUnitySections {
+    const val ADVANCED = "advanced"
+    const val LATEST = "latest"
+    const val CALENDAR = "calendar"
+    const val ONGOING = "ongoing"
+    const val POPULAR = "popular"
+    const val BEST = "best"
+    const val UPCOMING = "upcoming"
+    const val RANDOM = "random"
+
+    const val DEFAULT_ORDER = "latest,calendar,random,ongoing,popular,best,upcoming"
+
+    val defaultOrderKeys = listOf(
+        LATEST,
+        CALENDAR,
+        RANDOM,
+        ONGOING,
+        POPULAR,
+        BEST,
+        UPCOMING,
+    )
+
+    val validKeys = defaultOrderKeys
+}

--- a/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnitySettings.kt
+++ b/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/AnimeUnitySettings.kt
@@ -329,6 +329,12 @@ class AnimeUnitySettings : AnimeUnityBaseSettingsFragment() {
             getString("settings_menu_display_summary")
         view.findViewByName<TextView>("display_settings_action")?.text =
             getString("settings_open_action")
+        view.findViewByName<TextView>("cache_settings_title")?.text =
+            getString("settings_menu_cache_title")
+        view.findViewByName<TextView>("cache_settings_summary")?.text =
+            getString("settings_menu_cache_summary")
+        view.findViewByName<TextView>("cache_settings_action")?.text =
+            getString("settings_open_action")
         view.findViewByName<TextView>("advanced_search_settings_title")?.text =
             getString("settings_menu_advanced_search_title")
         view.findViewByName<TextView>("advanced_search_settings_summary")?.text =
@@ -341,6 +347,7 @@ class AnimeUnitySettings : AnimeUnityBaseSettingsFragment() {
 
         val homeSettingsCard: View? = view.findViewByName("home_settings_card")
         val displaySettingsCard: View? = view.findViewByName("display_settings_card")
+        val cacheSettingsCard: View? = view.findViewByName("cache_settings_card")
         val advancedSearchSettingsCard: View? = view.findViewByName("advanced_search_settings_card")
         val advancedSearchSwitch: Switch? = view.findViewByName("advanced_search_settings_switch")
         val siteUrlContainer: View? = view.findViewByName("site_url_container")
@@ -350,7 +357,7 @@ class AnimeUnitySettings : AnimeUnityBaseSettingsFragment() {
         val resetSettingsButton: TextView? = view.findViewByName("reset_settings_btn")
         val advancedSearchActionEnabledColor = advancedSearchAction?.currentTextColor ?: Color.WHITE
 
-        listOf(homeSettingsCard, displaySettingsCard, advancedSearchSettingsCard).forEach { card ->
+        listOf(homeSettingsCard, displaySettingsCard, cacheSettingsCard, advancedSearchSettingsCard).forEach { card ->
             card?.makeTvCompatible()
         }
         siteUrlContainer?.applyOutlineBackground()
@@ -460,6 +467,13 @@ class AnimeUnitySettings : AnimeUnityBaseSettingsFragment() {
             )
         }
 
+        cacheSettingsCard?.setOnClickListener {
+            AnimeUnityCacheSettingsFragment().show(
+                parentFragmentManager,
+                "AnimeUnityCacheSettings"
+            )
+        }
+
         advancedSearchSettingsCard?.setOnClickListener {
             if (advancedSearchSwitch?.isChecked == true) {
                 AnimeUnityAdvancedSearchSettingsFragment().show(
@@ -494,18 +508,28 @@ class AnimeUnityHomeSettingsFragment : AnimeUnityBaseSettingsFragment() {
         )
     }
 
-    private fun getCount(prefKey: String): Int {
-        return (sharedPref?.getInt(prefKey, AnimeUnityPlugin.DEFAULT_SECTION_COUNT)
-            ?: AnimeUnityPlugin.DEFAULT_SECTION_COUNT).coerceIn(1, AnimeUnityPlugin.MAX_SECTION_COUNT)
+    private fun getDefaultCount(prefKey: String): Int {
+        return if (prefKey == AnimeUnityPlugin.PREF_RANDOM_COUNT) {
+            AnimeUnityPlugin.DEFAULT_RANDOM_COUNT
+        } else {
+            AnimeUnityPlugin.DEFAULT_SECTION_COUNT
+        }
     }
 
-    private fun parseCount(input: EditText?): Int {
+    private fun getCount(prefKey: String): Int {
+        val defaultCount = getDefaultCount(prefKey)
+        return (sharedPref?.getInt(prefKey, defaultCount)
+            ?: defaultCount).coerceIn(1, AnimeUnityPlugin.MAX_SECTION_COUNT)
+    }
+
+    private fun parseCount(input: EditText?, prefKey: String): Int {
+        val defaultCount = getDefaultCount(prefKey)
         return input?.text
             ?.toString()
             ?.trim()
             ?.toIntOrNull()
             ?.coerceIn(1, AnimeUnityPlugin.MAX_SECTION_COUNT)
-            ?: AnimeUnityPlugin.DEFAULT_SECTION_COUNT
+            ?: defaultCount
     }
 
     private fun setupCountInput(input: EditText?, prefKey: String) {
@@ -585,7 +609,7 @@ class AnimeUnityHomeSettingsFragment : AnimeUnityBaseSettingsFragment() {
 
         val sectionRows = listOf(
             SectionRow(
-                key = "latest",
+                key = AnimeUnitySections.LATEST,
                 rowId = "latest_row",
                 labelStringName = "latest_count_label",
                 titlePrefKey = AnimeUnityPlugin.PREF_LATEST_TITLE,
@@ -593,7 +617,7 @@ class AnimeUnityHomeSettingsFragment : AnimeUnityBaseSettingsFragment() {
                 countPrefKey = AnimeUnityPlugin.PREF_LATEST_COUNT,
             ),
             SectionRow(
-                key = "calendar",
+                key = AnimeUnitySections.CALENDAR,
                 rowId = "calendar_row",
                 labelStringName = "calendar_switch_text",
                 titlePrefKey = AnimeUnityPlugin.PREF_CALENDAR_TITLE,
@@ -601,7 +625,7 @@ class AnimeUnityHomeSettingsFragment : AnimeUnityBaseSettingsFragment() {
                 countPrefKey = AnimeUnityPlugin.PREF_CALENDAR_COUNT,
             ),
             SectionRow(
-                key = "ongoing",
+                key = AnimeUnitySections.ONGOING,
                 rowId = "ongoing_row",
                 labelStringName = "ongoing_count_label",
                 titlePrefKey = AnimeUnityPlugin.PREF_ONGOING_TITLE,
@@ -609,7 +633,7 @@ class AnimeUnityHomeSettingsFragment : AnimeUnityBaseSettingsFragment() {
                 countPrefKey = AnimeUnityPlugin.PREF_ONGOING_COUNT,
             ),
             SectionRow(
-                key = "popular",
+                key = AnimeUnitySections.POPULAR,
                 rowId = "popular_row",
                 labelStringName = "popular_count_label",
                 titlePrefKey = AnimeUnityPlugin.PREF_POPULAR_TITLE,
@@ -617,7 +641,7 @@ class AnimeUnityHomeSettingsFragment : AnimeUnityBaseSettingsFragment() {
                 countPrefKey = AnimeUnityPlugin.PREF_POPULAR_COUNT,
             ),
             SectionRow(
-                key = "best",
+                key = AnimeUnitySections.BEST,
                 rowId = "best_row",
                 labelStringName = "best_count_label",
                 titlePrefKey = AnimeUnityPlugin.PREF_BEST_TITLE,
@@ -625,7 +649,7 @@ class AnimeUnityHomeSettingsFragment : AnimeUnityBaseSettingsFragment() {
                 countPrefKey = AnimeUnityPlugin.PREF_BEST_COUNT,
             ),
             SectionRow(
-                key = "upcoming",
+                key = AnimeUnitySections.UPCOMING,
                 rowId = "upcoming_row",
                 labelStringName = "upcoming_count_label",
                 titlePrefKey = AnimeUnityPlugin.PREF_UPCOMING_TITLE,
@@ -633,7 +657,7 @@ class AnimeUnityHomeSettingsFragment : AnimeUnityBaseSettingsFragment() {
                 countPrefKey = AnimeUnityPlugin.PREF_UPCOMING_COUNT,
             ),
             SectionRow(
-                key = "random",
+                key = AnimeUnitySections.RANDOM,
                 rowId = "random_row",
                 labelStringName = "random_count_label",
                 titlePrefKey = AnimeUnityPlugin.PREF_RANDOM_TITLE,
@@ -712,7 +736,7 @@ class AnimeUnityHomeSettingsFragment : AnimeUnityBaseSettingsFragment() {
                     sectionRow.countPrefKey?.let { prefKey ->
                         putInt(
                             prefKey,
-                            parseCount(rowView.findViewByName("row_count_input"))
+                            parseCount(rowView.findViewByName("row_count_input"), prefKey)
                         )
                     }
 
@@ -731,6 +755,67 @@ class AnimeUnityHomeSettingsFragment : AnimeUnityBaseSettingsFragment() {
                     ?: "Impostazioni salvate. Riavvia l'applicazione per applicarle"
             )
             dismiss()
+        }
+    }
+}
+
+class AnimeUnityCacheSettingsFragment : AnimeUnityBaseSettingsFragment() {
+
+    override val layoutName: String = "settings_cache"
+
+    private fun formatBytes(bytes: Long): String {
+        val mb = bytes / (1024.0 * 1024.0)
+        return String.format(java.util.Locale.ITALY, "%.1f MB", mb)
+    }
+
+    private fun updateStats(view: View) {
+        AnimeUnityCache.init(view.context.applicationContext)
+        val stats = AnimeUnityCache.stats()
+        view.findViewByName<TextView>("cache_stats_summary")?.text =
+            (getString("settings_cache_stats_summary")
+                ?: "%1\$d elementi | %2\$d schede anime | %3\$d pagine anime | %4\$d scaduti | %5\$s").format(
+                stats.entryCount,
+                stats.detailEntryCount,
+                stats.animePageEntryCount,
+                stats.expiredEntryCount,
+                formatBytes(stats.totalBytes),
+            )
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        view.findViewByName<TextView>("header_tw")?.text =
+            getString("settings_cache_title")
+        view.findViewByName<View>("cache_stats_card")?.applyOutlineBackground()
+        view.findViewByName<TextView>("cache_stats_title")?.text =
+            getString("settings_cache_stats_title")
+
+        val clearCacheButton: TextView? = view.findViewByName("clear_cache_btn")
+        clearCacheButton?.apply {
+            makeTvCompatible()
+            background = getDrawable("outline_danger")
+            setTextColor(Color.parseColor("#FFFF7F7F"))
+            text = getString("settings_cache_clear_button")
+        }
+
+        updateStats(view)
+
+        clearCacheButton?.setOnClickListener {
+            val context = context ?: return@setOnClickListener
+            AlertDialog.Builder(context)
+                .setTitle(getString("settings_cache_clear_title") ?: "Svuota cache")
+                .setMessage(
+                    getString("settings_cache_clear_message")
+                        ?: "Vuoi eliminare i dati salvati di AnimeUnity?"
+                )
+                .setPositiveButton(getString("settings_cache_clear_confirm") ?: "Svuota") { _, _ ->
+                    AnimeUnity.clearAllCaches()
+                    updateStats(view)
+                    showToast(getString("settings_cache_cleared") ?: "Cache svuotata")
+                }
+                .setNegativeButton(getString("settings_reset_cancel") ?: "Annulla", null)
+                .show()
         }
     }
 }

--- a/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/VixCloudExtractor.kt
+++ b/AnimeUnity/src/main/kotlin/it/dogior/hadEnough/VixCloudExtractor.kt
@@ -16,13 +16,16 @@ class VixCloudExtractor(
     override val mainUrl = "vixcloud.co"
     override val name = "VixCloud"
     override val requiresReferer = false
-    private val TAG = "VixCloudExtractor"
-    private val h = mutableMapOf(
+    private val headers = mutableMapOf(
         "Accept" to "*/*",
         "Connection" to "keep-alive",
         "Cache-Control" to "no-cache",
         "user-agent" to "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:131.0) Gecko/20100101 Firefox/131.0",
     )
+
+    private companion object {
+        const val LOG_TAG = "VixCloudExtractor"
+    }
 
     override suspend fun getUrl(
         url: String,
@@ -30,25 +33,25 @@ class VixCloudExtractor(
         subtitleCallback: (SubtitleFile) -> Unit,
         callback: (ExtractorLink) -> Unit
     ) {
-        Log.d(TAG, "REFERER: $referer  URL: $url")
+        Log.d(LOG_TAG, "REFERER: $referer  URL: $url")
         val playlistUrl = getPlaylistLink(url)
 
-        Log.d(TAG, "FINAL URL: $playlistUrl")
+        Log.d(LOG_TAG, "FINAL URL: $playlistUrl")
 
-        callback.invoke(
+        callback(
             newExtractorLink(
                 source = sourceName,
                 name = displayName,
                 url = playlistUrl,
                 type = ExtractorLinkType.M3U8
             ) {
-                this.headers = h
+                this.headers = this@VixCloudExtractor.headers
             }
         )
     }
 
     private suspend fun getPlaylistLink(url: String): String {
-        Log.d(TAG, "Item url: $url")
+        Log.d(LOG_TAG, "Item url: $url")
 
         val script = getScript(url)
         val masterPlaylist = script.getJSONObject("masterPlaylist")
@@ -57,34 +60,36 @@ class VixCloudExtractor(
         val expires = masterPlaylistParams.getString("expires")
         val playlistUrl = masterPlaylist.getString("url")
 
-        var masterPlaylistUrl: String
-        val params = "token=${token}&expires=${expires}"
-        masterPlaylistUrl = if ("?b" in playlistUrl) {
+        val params = "token=$token&expires=$expires"
+        val basePlaylistUrl = if ("?b" in playlistUrl) {
             "${playlistUrl.replace("?b:1", "?b=1")}&$params"
         } else {
             "${playlistUrl}?$params"
         }
-        Log.d(TAG, "masterPlaylistUrl: $masterPlaylistUrl")
-
-        if (script.getBoolean("canPlayFHD")) {
-            masterPlaylistUrl += "&h=1"
+        val masterPlaylistUrl = if (script.getBoolean("canPlayFHD")) {
+            "$basePlaylistUrl&h=1"
+        } else {
+            basePlaylistUrl
         }
 
-        Log.d(TAG, "Master Playlist URL: $masterPlaylistUrl")
+        Log.d(LOG_TAG, "Master Playlist URL: $masterPlaylistUrl")
         return masterPlaylistUrl
     }
 
     private suspend fun getScript(url: String): JSONObject {
-        Log.d(TAG, "Embed url: $url")
+        Log.d(LOG_TAG, "Embed url: $url")
 
-        val iframe = app.get(url, headers = h).document
+        val iframe = app.get(url, headers = headers).document
 
         val scripts = iframe.select("script")
-        val script =
-            scripts.find { it.data().contains("masterPlaylist") }!!.data().replace("\n", "\t")
+        val script = scripts
+            .firstOrNull { it.data().contains("masterPlaylist") }
+            ?.data()
+            ?.replace("\n", "\t")
+            ?: error("Missing VixCloud masterPlaylist script")
 
         val scriptJson = getSanitisedScript(script)
-        Log.d(TAG, "Script Json: $scriptJson")
+        Log.d(LOG_TAG, "Script Json: $scriptJson")
         return JSONObject(scriptJson)
     }
 

--- a/AnimeUnity/src/main/res/layout/settings.xml
+++ b/AnimeUnity/src/main/res/layout/settings.xml
@@ -133,6 +133,48 @@
     </LinearLayout>
 
     <LinearLayout
+        android:id="@+id/cache_settings_card"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center_vertical"
+        android:minHeight="68dp"
+        android:orientation="horizontal"
+        android:padding="14dp">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/cache_settings_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textSize="17sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/cache_settings_summary"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:alpha="0.8"
+                android:textSize="13sp" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/cache_settings_action"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <LinearLayout
         android:id="@+id/advanced_search_settings_card"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/AnimeUnity/src/main/res/layout/settings_cache.xml
+++ b/AnimeUnity/src/main/res/layout/settings_cache.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="8dp">
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="42dp">
+
+        <TextView
+            android:id="@+id/header_tw"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_centerVertical="true"
+            android:textSize="22sp"
+            android:textStyle="bold" />
+    </RelativeLayout>
+
+    <LinearLayout
+        android:id="@+id/cache_stats_card"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:orientation="vertical"
+        android:padding="14dp">
+
+        <TextView
+            android:id="@+id/cache_stats_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="17sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/cache_stats_summary"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:alpha="0.82"
+            android:textSize="13sp" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/clear_cache_btn"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center"
+        android:minHeight="52dp"
+        android:paddingHorizontal="18dp"
+        android:paddingVertical="14dp"
+        android:textStyle="bold" />
+</LinearLayout>

--- a/AnimeUnity/src/main/res/values/strings.xml
+++ b/AnimeUnity/src/main/res/values/strings.xml
@@ -7,6 +7,8 @@
     <string name="settings_menu_home_summary">Personalizza Home</string>
     <string name="settings_menu_display_title">Preferenze</string>
     <string name="settings_menu_display_summary">Schede e dettagli anime</string>
+    <string name="settings_menu_cache_title">Cache</string>
+    <string name="settings_menu_cache_summary">Gestisci dati salvati e refresh</string>
     <string name="settings_menu_advanced_search_title">Ricerca avanzata</string>
     <string name="settings_menu_advanced_search_summary">Ricerca Anime per criteri</string>
     <string name="settings_open_action">Apri</string>
@@ -38,6 +40,14 @@
     <string name="random_count_label">Random</string>
 
     <string name="settings_display_title">Preferenze</string>
+    <string name="settings_cache_title">Cache</string>
+    <string name="settings_cache_stats_title">Spazio cache</string>
+    <string name="settings_cache_stats_summary">%1$d elementi | %2$d schede anime | %3$d pagine anime | %4$d scaduti | %5$s</string>
+    <string name="settings_cache_clear_button">Svuota cache</string>
+    <string name="settings_cache_clear_title">Svuota cache</string>
+    <string name="settings_cache_clear_message">Vuoi eliminare i dati salvati di AnimeUnity? La prossima apertura ricarichera tutto dal server.</string>
+    <string name="settings_cache_clear_confirm">Svuota</string>
+    <string name="settings_cache_cleared">Cache svuotata</string>
     <string name="settings_advanced_search_title">Ricerca avanzata</string>
     <string name="unify_dub_sub_cards_switch_text">Scheda unica SUB/DUB</string>
     <string name="dub_sub_switch_text">SUB / DUB</string>


### PR DESCRIPTION
## Metadata Episodi
- Vengono mostrate diverse informazioni (fonte AniZip) che riguardano l'episodio:
  - copertina (fallback al banner dell’anime se non disponibili)
  - titolo 
  - descrizione
  - durata 
  - valutazione
  - data di pubblicazione

## Gestione migliorata SUB/DUB
  - Non vengono più generati episodi "vuoti" quando il numero di episodi DUB differisce dai SUB.
  - Ora se un anime ha sia la versione DUB che la versione SUB vengono mostrati due badge (nota: nella home questo viene gestito diversamente, esempio: nella sezione **Popolari** l'anime _Jujutsu Kaisen_ viene segnalato solamente con SUB mentre nella ricerca viene segnalato SUB e DUB)

## Migliorie 
- Aggiunta la visualizzazione del numero totale di episodi (escluso per le sezioni Ultimi Episodi e Calendario che continuano a mostrare l'episodio uscito)
- Aggiunte le cache, per rendere il caricamento sia della home che degli episodi molto più veloce #95 

## Fix
- Rivisto un minimo il tracciamento
- Risolto un problema relativo alla sezione e al numero di schede da mostrare
- Risolto un problema che poteva mostrare meno schede nella home, quindi invece di mostrare 14 ne mostrava 13 o di meno 

## Codice
- Rivisto il codice di AnimeUnity